### PR TITLE
Read teams by sessionKey, teamId

### DIFF
--- a/the-backfield/DTOs/ResponseDTO.cs
+++ b/the-backfield/DTOs/ResponseDTO.cs
@@ -6,7 +6,5 @@
         public bool Forbidden { get; set; } = false;
         public bool NotFound { get; set; } = false;
         public string? ErrorMessage { get; set; }
-        public object? Resource { get; set; }
-        public int ResourceId { get; set; }
     }
 }

--- a/the-backfield/DTOs/TeamResponseDTO.cs
+++ b/the-backfield/DTOs/TeamResponseDTO.cs
@@ -1,0 +1,12 @@
+﻿using TheBackfield.DTOs;
+using TheBackfield.Models;
+
+namespace TheBackfield.DTOs
+{
+    public class TeamResponseDTO : ResponseDTO
+    {
+        public Team? Team { get; set; }
+        public int TeamId { get; set; }
+        public List<Team> Teams { get; set; } = [];
+    }
+}

--- a/the-backfield/Interfaces/ITeamRepository.cs
+++ b/the-backfield/Interfaces/ITeamRepository.cs
@@ -5,7 +5,7 @@ namespace TheBackfield.Interfaces;
 
 public interface ITeamRepository
 {
-    Task<List<Team>> GetTeamsAsync(int userId);
+    Task<List<Team>> GetTeamsByUserIdAsync(int userId);
     Task<Team?> GetSingleTeamAsync(int teamId);
     Task<Team> CreateTeamAsync(TeamSubmitDTO teamSubmit, int userId);
     Task<Team?> UpdateTeamAsync(TeamSubmitDTO teamSubmit);

--- a/the-backfield/Interfaces/ITeamService.cs
+++ b/the-backfield/Interfaces/ITeamService.cs
@@ -5,9 +5,9 @@ namespace TheBackfield.Interfaces;
 
 public interface ITeamService
 {
-    Task<List<Team>> GetTeamsAsync(int userId);
-    Task<Team?> GetSingleTeamAsync(int teamId, int userId);
-    Task<ResponseDTO> CreateTeamAsync(TeamSubmitDTO teamSubmit);
-    Task<ResponseDTO> UpdateTeamAsync(TeamSubmitDTO teamSubmit);
+    Task<TeamResponseDTO> GetTeamsBySessionKeyAsync(string sessionKey);
+    Task<TeamResponseDTO> GetSingleTeamAsync(int teamId, string sessionKey);
+    Task<TeamResponseDTO> CreateTeamAsync(TeamSubmitDTO teamSubmit);
+    Task<TeamResponseDTO> UpdateTeamAsync(TeamSubmitDTO teamSubmit);
     Task<Team> DeleteTeamAsync(int teamId, int userId);
 }

--- a/the-backfield/Repositories/TeamRepository.cs
+++ b/the-backfield/Repositories/TeamRepository.cs
@@ -41,12 +41,14 @@ public class TeamRepository : ITeamRepository
 
     public async Task<Team?> GetSingleTeamAsync(int teamId)
     {
-        return await _dbContext.Teams.SingleOrDefaultAsync(t => t.Id == teamId);
+        return await _dbContext.Teams
+            .Include(t => t.Players)
+            .SingleOrDefaultAsync(t => t.Id == teamId);
     }
 
-    public Task<List<Team>> GetTeamsAsync(int userId)
+    public async Task<List<Team>> GetTeamsByUserIdAsync(int userId)
     {
-        throw new NotImplementedException();
+        return await _dbContext.Teams.Where(t => t.UserId == userId).ToListAsync();
     }
 
     public async Task<Team?> UpdateTeamAsync(TeamSubmitDTO teamSubmit)

--- a/the-backfield/Utilities/SessionKeyClient.cs
+++ b/the-backfield/Utilities/SessionKeyClient.cs
@@ -34,21 +34,21 @@ namespace TheBackfield.Utilities
         /// <param name="user"></param>
         /// <param name="team"></param>
         /// <returns>ResponseDTO with Response = Team if access granted, Error = IResult if access denied </returns>
-        public static ResponseDTO VerifyAccess(string sessionKey, User? user, Team? team)
+        public static TeamResponseDTO VerifyAccess(string sessionKey, User? user, Team? team)
         {
             if (team == null)
             {
-                return new ResponseDTO { NotFound = true, ErrorMessage = "Invalid team id" };
+                return new TeamResponseDTO { NotFound = true, ErrorMessage = "Invalid team id" };
             }
             if (user == null || user.SessionKey != sessionKey)
             {
-                return new ResponseDTO { Unauthorized = true, ErrorMessage = "Invalid session key" };
+                return new TeamResponseDTO { Unauthorized = true, ErrorMessage = "Invalid session key" };
             }
             if (team.UserId != user.Id)
             {
-                return new ResponseDTO { Forbidden = true, ErrorMessage = "User does not have access" };
+                return new TeamResponseDTO { Forbidden = true, ErrorMessage = "User does not have access" };
             }
-            return new ResponseDTO { Resource = team, ResourceId = team.Id };
+            return new TeamResponseDTO { Team = team, TeamId = team.Id };
         }
     }
 }


### PR DESCRIPTION
Added APIs to read all teams by sessionKey, single team by teamId (with sessionKey validation)

Created TeamResponseDTO that inherits from ResponseDTO, containing Team, TeamId, and Teams properties for increased typing

Fixed error where Results.Forbid() threw a 500, changed to Results.StatusCode(403)