### PR TITLE
Create and Update Games

### DIFF
--- a/the-backfield/DTOs/GameSubmitDTO.cs
+++ b/the-backfield/DTOs/GameSubmitDTO.cs
@@ -1,18 +1,50 @@
 using System.ComponentModel.DataAnnotations;
+using System.Numerics;
+using TheBackfield.Models;
 
 namespace TheBackfield.DTOs;
 
 public class GameSubmitDTO
 {
     public int Id { get; set; }
-    [Required]
-    public int HomeTeamId { get; set; }
-    public int HomeTeamScore { get; set; }
-    [Required]
-    public int AwayTeamId { get; set; }
-    public int AwayTeamScore { get; set; }
-    public DateTime GameStart { get; set; }
-    public int GamePeriods { get; set; }
-    public int PeriodLength { get; set; }
-    public int SessionKey { get; set; }
+    public int HomeTeamId { get; set; } = 0;
+    public int? HomeTeamScore { get; set; }
+    public int AwayTeamId { get; set; } = 0;
+    public int? AwayTeamScore { get; set; }
+    public DateTime? GameStart { get; set; }
+    public int? GamePeriods { get; set; }
+    public int? PeriodLength { get; set; }
+    public string? SessionKey { get; set; }
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="userId"></param>
+    /// <param name="mapOntoGame">Game to map non-null</param>
+    /// <returns></returns>
+    public Game MapToGame(int userId, Game? mapOntoGame = null)
+    {
+        if (mapOntoGame == null)
+        {
+            mapOntoGame = new Game();
+        }
+
+        Game mappedGame = new()
+        {
+            HomeTeamId = HomeTeamId != 0 ? HomeTeamId : mapOntoGame.HomeTeamId,
+            HomeTeamScore = HomeTeamScore ?? mapOntoGame.HomeTeamScore,
+            AwayTeamId = AwayTeamId != 0 ? AwayTeamId : mapOntoGame.AwayTeamId,
+            AwayTeamScore = AwayTeamScore ?? mapOntoGame.AwayTeamScore,
+            GameStart = GameStart ?? mapOntoGame.GameStart,
+            GamePeriods = GamePeriods ?? mapOntoGame.GamePeriods,
+            PeriodLength = PeriodLength ?? mapOntoGame.PeriodLength,
+            UserId = userId,
+        };
+
+        if (mapOntoGame.Id != 0)
+        {
+            mappedGame.Id = mapOntoGame.Id;
+        }
+
+        return mappedGame;
+    }
 }

--- a/the-backfield/DTOs/ResponseDTO.cs
+++ b/the-backfield/DTOs/ResponseDTO.cs
@@ -6,11 +6,18 @@
         public bool Forbidden { get; set; } = false;
         public bool NotFound { get; set; } = false;
         public string? ErrorMessage { get; set; }
+        public bool Error
+        {
+            get
+            { 
+                return Unauthorized == true || Forbidden == true || NotFound == true || ErrorMessage != null;
+            }
+        }
         /// <summary>
         /// Throws error as IResult
         /// <br/>Converts any error data stored in DTO
         /// </summary>
-        /// <returns>Error as IResult (if no error tags marked, returns Results.BadRequest())</returns>
+        /// <returns>Error as IResult (if no error tags marked, returns Results.BadRequest(ErrorMessage))</returns>
         public IResult ThrowError()
         {
             if (NotFound)
@@ -25,7 +32,7 @@
             {
                 return Results.StatusCode(403);
             }
-            return Results.BadRequest();
+            return Results.BadRequest(ErrorMessage ?? "");
         }
 
         public PlayerResponseDTO CastToPlayerResponseDTO()
@@ -42,6 +49,17 @@
         public TeamResponseDTO CastToTeamResponseDTO()
         {
             return new TeamResponseDTO
+            {
+                NotFound = NotFound,
+                Unauthorized = Unauthorized,
+                Forbidden = Forbidden,
+                ErrorMessage = ErrorMessage
+            };
+        }
+
+        public GameResponseDTO CastToGameResponseDTO()
+        {
+            return new GameResponseDTO
             {
                 NotFound = NotFound,
                 Unauthorized = Unauthorized,

--- a/the-backfield/Interfaces/IGameRepository.cs
+++ b/the-backfield/Interfaces/IGameRepository.cs
@@ -7,7 +7,7 @@ public interface IGameRepository
 {
     Task<List<Game>> GetAllGamesAsync(int userId);
     Task<Game?> GetSingleGameAsync(int gameId);
-    Task<Game> CreateGameAsync(GameSubmitDTO gameSubmit);
-    Task<Game> UpdateGameAsync(GameSubmitDTO gameSubmit);
+    Task<Game> CreateGameAsync(Game newGame);
+    Task<Game?> UpdateGameAsync(Game updatedGame);
     Task<string?> DeleteGameAsync(int gameId, int userId);
 }

--- a/the-backfield/Repositories/GameRepository.cs
+++ b/the-backfield/Repositories/GameRepository.cs
@@ -32,14 +32,31 @@ public class GameRepository : IGameRepository
             .SingleOrDefaultAsync(g => g.Id == gameId);
     }
 
-    public Task<Game> CreateGameAsync(GameSubmitDTO gameSubmit)
+    public async Task<Game> CreateGameAsync(Game newGame)
     {
-        throw new NotImplementedException();
+        _dbContext.Games.Add(newGame);
+        await _dbContext.SaveChangesAsync();
+        return newGame;
     }
 
-    public Task<Game> UpdateGameAsync(GameSubmitDTO gameSubmit)
+    public async Task<Game?> UpdateGameAsync(Game updatedGame)
     {
-        throw new NotImplementedException();
+        Game? game = await _dbContext.Games.FindAsync(updatedGame.Id);
+        if (game == null)
+        {
+            return null;
+        }
+
+        game.HomeTeamId = updatedGame.HomeTeamId;
+        game.HomeTeamScore = updatedGame.HomeTeamScore;
+        game.AwayTeamId = updatedGame.AwayTeamId;
+        game.AwayTeamScore = updatedGame.AwayTeamScore;
+        game.GameStart = updatedGame.GameStart;
+        game.GamePeriods = updatedGame.GamePeriods;
+        game.PeriodLength = updatedGame.PeriodLength;
+
+        await _dbContext.SaveChangesAsync();
+        return game;
     }
 
     public Task<string?> DeleteGameAsync(int gameId, int userId)

--- a/the-backfield/Services/GameService.cs
+++ b/the-backfield/Services/GameService.cs
@@ -8,17 +8,44 @@ namespace TheBackfield.Services;
 public class GameService : IGameService
 {
     private readonly IGameRepository _gameRepository;
+    private readonly ITeamRepository _teamRepository;
     private readonly IUserRepository _userRepository;
 
-    public GameService(IGameRepository gameRepository, IUserRepository userRepository)
+    public GameService(IGameRepository gameRepository, ITeamRepository teamRepository, IUserRepository userRepository)
     {
         _gameRepository = gameRepository;
+        _teamRepository = teamRepository;
         _userRepository = userRepository;
     }
 
     public async Task<GameResponseDTO> CreateGameAsync(GameSubmitDTO gameSubmit)
     {
-        return new GameResponseDTO { Game = await _gameRepository.CreateGameAsync(gameSubmit) };
+        User? user = await _userRepository.GetUserBySessionKeyAsync(gameSubmit.SessionKey);
+        if (user == null)
+        {
+            return new GameResponseDTO { Unauthorized = true, ErrorMessage = "Invalid session key" };
+        }
+
+        if (gameSubmit.HomeTeamId == gameSubmit.AwayTeamId)
+        {
+            return new GameResponseDTO { ErrorMessage = "Home team and away team cannot be identical" };
+        }
+
+        Team? homeTeam = await _teamRepository.GetSingleTeamAsync(gameSubmit.HomeTeamId);
+        TeamResponseDTO teamCheck = SessionKeyClient.VerifyAccess(gameSubmit.SessionKey, user, homeTeam);
+        if (teamCheck.ErrorMessage != null)
+        {
+            return teamCheck.CastToGameResponseDTO();
+        }
+
+        Team? awayTeam = await _teamRepository.GetSingleTeamAsync(gameSubmit.AwayTeamId);
+        teamCheck = SessionKeyClient.VerifyAccess(gameSubmit.SessionKey, user, awayTeam);
+        if (teamCheck.ErrorMessage != null)
+        {
+            return teamCheck.CastToGameResponseDTO();
+        }
+
+        return new GameResponseDTO { Game = await _gameRepository.CreateGameAsync(gameSubmit.MapToGame(user.Id)) };
     }
 
     public async Task<string?> DeleteGameAsync(int gameId, int userId)
@@ -31,7 +58,7 @@ public class GameService : IGameService
         User? user = await _userRepository.GetUserBySessionKeyAsync(sessionKey);
         if (user == null)
         {
-            return new GameResponseDTO { Unauthorized = true, ErrorMessage = "Invalid user id" };
+            return new GameResponseDTO { Unauthorized = true, ErrorMessage = "Invalid session key" };
         }
         return new GameResponseDTO { Games = await _gameRepository.GetAllGamesAsync(user.Id) };
     }
@@ -45,6 +72,35 @@ public class GameService : IGameService
 
     public async Task<GameResponseDTO> UpdateGameAsync(GameSubmitDTO gameSubmit)
     {
-        return new GameResponseDTO { Game = await _gameRepository.UpdateGameAsync(gameSubmit) };
+        User? user = await _userRepository.GetUserBySessionKeyAsync(gameSubmit.SessionKey);
+        Game? game = await _gameRepository.GetSingleGameAsync(gameSubmit.Id);
+        GameResponseDTO gameCheck = SessionKeyClient.VerifyAccess(gameSubmit.SessionKey, user, game);
+        if (gameCheck.Error)
+        {
+            return gameCheck;
+        }
+
+        Game updatedGame = gameSubmit.MapToGame(user.Id, game);
+
+        if (updatedGame.HomeTeamId == updatedGame.AwayTeamId)
+        {
+            return new GameResponseDTO { ErrorMessage = "Home team and away team cannot be identical" };
+        }
+
+        Team? homeTeam = await _teamRepository.GetSingleTeamAsync(updatedGame.HomeTeamId);
+        TeamResponseDTO teamCheck = SessionKeyClient.VerifyAccess(gameSubmit.SessionKey, user, homeTeam);
+        if (teamCheck.Error)
+        {
+            return teamCheck.CastToGameResponseDTO();
+        }
+
+        Team? awayTeam = await _teamRepository.GetSingleTeamAsync(updatedGame.AwayTeamId);
+        teamCheck = SessionKeyClient.VerifyAccess(gameSubmit.SessionKey, user, awayTeam);
+        if (teamCheck.Error)
+        {
+            return teamCheck.CastToGameResponseDTO();
+        }
+
+        return new GameResponseDTO { Game = await _gameRepository.UpdateGameAsync(updatedGame) };
     }
 }


### PR DESCRIPTION
Added POST /games and PUT /games/{gameId} (if gameId is not for an existing game, PUT will create a new game from the GameSubmitDTO.

Added CreateGameAsync and UpdateGameAsync functionality to GameRepository and adjusted input to accept a Game object rather than a GameSubmitDTO and userId.

Added CreateGameAsync and UpdateGameAsync functionality to GameService.

Added GameSubmitDTO.MapToGame(int userId, Game? game) where the "game" parameter is optional. Use if wishing to write data from GameSubmitDTO onto an existing game. Output is a Game object.

Added ResponseDTO.Error computed property that reads true when Unauthorized, Forbidden, Not Found, or Error Message are no longer falsy. Broadens and simplifies throwing of errors from ResponseDTO and objects that inherit from it.

Added ResponseDTO.CastToGameResponseDTO()