### PR TITLE
Delete MVP entities

### DIFF
--- a/the-backfield/DTOs/ResponseDTO.cs
+++ b/the-backfield/DTOs/ResponseDTO.cs
@@ -68,7 +68,7 @@
             };
         }
         /// <summary>
-        /// 
+        /// Convert instance of ResponseDTO or any class that extends ResponseDTO to instance of type T. Only base class properties are transferred.
         /// </summary>
         /// <typeparam name="T">Class that extends base class ResponseDTO</typeparam>
         /// <returns></returns>

--- a/the-backfield/Endpoints/GameEndpoints.cs
+++ b/the-backfield/Endpoints/GameEndpoints.cs
@@ -77,5 +77,18 @@ public static class GameEndpoints
             .WithOpenApi()
             .Produces<Game>(StatusCodes.Status200OK)
             .Produces<Game>(StatusCodes.Status201Created);
+
+        group.MapDelete("/games/{gameId}", async (IGameService gameService, int gameId, string sessionKey) =>
+        {
+            GameResponseDTO response = await gameService.DeleteGameAsync(gameId, sessionKey);
+            if (response.Error)
+            {
+                return response.ThrowError();
+            }
+
+            return Results.NoContent();
+        })
+            .WithOpenApi()
+            .Produces(StatusCodes.Status204NoContent);
     }
 }

--- a/the-backfield/Endpoints/GameStatEndpoints.cs
+++ b/the-backfield/Endpoints/GameStatEndpoints.cs
@@ -40,5 +40,18 @@ public static class GameStatEndpoints
         })
             .WithOpenApi()
             .Produces<GameStat>(StatusCodes.Status200OK);
+
+        group.MapDelete("/game-stats/{gameStatId}", async (IGameStatService gameStatService, int gameStatId, string sessionKey) =>
+        {
+            GameStatResponseDTO response = await gameStatService.DeleteGameStatAsync(gameStatId, sessionKey);
+            if (response.Error)
+            {
+                return response.ThrowError();
+            }
+
+            return Results.NoContent();
+        })
+            .WithOpenApi()
+            .Produces(StatusCodes.Status204NoContent);
     }
 }

--- a/the-backfield/Endpoints/PlayerEndpoints.cs
+++ b/the-backfield/Endpoints/PlayerEndpoints.cs
@@ -114,5 +114,18 @@ public static class PlayerEndpoints
         })
             .WithOpenApi()
             .Produces<Player>(StatusCodes.Status200OK);
+
+        group.MapDelete("/players/{playerId}", async (IPlayerService playerService, int playerId, string sessionKey) =>
+        {
+            PlayerResponseDTO response = await playerService.DeletePlayerAsync(playerId, sessionKey);
+            if (response.Error)
+            {
+                return response.ThrowError();
+            }
+
+            return Results.NoContent();
+        })
+            .WithOpenApi()
+            .Produces(StatusCodes.Status204NoContent);
     }
 }

--- a/the-backfield/Endpoints/TeamEndpoints.cs
+++ b/the-backfield/Endpoints/TeamEndpoints.cs
@@ -117,5 +117,18 @@ public static class TeamEndpoints
         })
             .WithOpenApi()
             .Produces<Team>(StatusCodes.Status201Created);
+
+        group.MapDelete("/teams/{teamId}", async (ITeamService teamService, int teamId, string sessionKey) =>
+        {
+            TeamResponseDTO response = await teamService.DeleteTeamAsync(teamId, sessionKey);
+            if (response.Error)
+            {
+                return response.ThrowError();
+            }
+
+            return Results.NoContent();
+        })
+            .WithOpenApi()
+            .Produces(StatusCodes.Status204NoContent);
     }
 }

--- a/the-backfield/Interfaces/IGameRepository.cs
+++ b/the-backfield/Interfaces/IGameRepository.cs
@@ -9,5 +9,5 @@ public interface IGameRepository
     Task<Game?> GetSingleGameAsync(int gameId);
     Task<Game> CreateGameAsync(Game newGame);
     Task<Game?> UpdateGameAsync(Game updatedGame);
-    Task<string?> DeleteGameAsync(int gameId, int userId);
+    Task<string?> DeleteGameAsync(int gameId);
 }

--- a/the-backfield/Interfaces/IGameService.cs
+++ b/the-backfield/Interfaces/IGameService.cs
@@ -9,5 +9,5 @@ public interface IGameService
     Task<GameResponseDTO> GetSingleGameAsync(int gameId, string sessionKey);
     Task<GameResponseDTO> CreateGameAsync(GameSubmitDTO gameSubmit);
     Task<GameResponseDTO> UpdateGameAsync(GameSubmitDTO gameSubmit);
-    Task<string?> DeleteGameAsync(int gameId, int userId);
+    Task<GameResponseDTO> DeleteGameAsync(int gameId, string sessionKey);
 }

--- a/the-backfield/Interfaces/IGameStatRepository.cs
+++ b/the-backfield/Interfaces/IGameStatRepository.cs
@@ -8,5 +8,5 @@ public interface IGameStatRepository
     Task<GameStat?> GetSingleGameStatAsync(int gameStatId);
     Task<GameStat> CreateGameStatAsync(GameStat newGameStat);
     Task<GameStat?> UpdateGameStatAsync(GameStat updatedGameStat);
-    Task<string?> DeleteGameStatAsync(int gameStatId, int userId);
+    Task<string?> DeleteGameStatAsync(int gameStatId);
 }

--- a/the-backfield/Interfaces/IGameStatService.cs
+++ b/the-backfield/Interfaces/IGameStatService.cs
@@ -7,5 +7,5 @@ public interface IGameStatService
 {
     Task<GameStatResponseDTO> CreateGameStatAsync(GameStatSubmitDTO gameStatSubmit);
     Task<GameStatResponseDTO> UpdateGameStatAsync(GameStatSubmitDTO gameStatSubmit);
-    Task<string?> DeleteGameStatAsync(int gameStatId, int userId);
+    Task<GameStatResponseDTO> DeleteGameStatAsync(int gameStatId, string sessionKey);
 }

--- a/the-backfield/Interfaces/IPlayerRepository.cs
+++ b/the-backfield/Interfaces/IPlayerRepository.cs
@@ -9,7 +9,7 @@ public interface IPlayerRepository
     Task<Player?> GetSinglePlayerAsync(int playerId);
     Task<Player> CreatePlayerAsync(Player newPlayer);
     Task<Player?> UpdatePlayerAsync(Player updatedPlayer);
-    Task<string?> DeletePlayerAsync(int playerId, int userId);
+    Task<string?> DeletePlayerAsync(int playerId);
     Task<Player?> SetPlayerPositionsAsync(int playerId, List<int> positionIds);
     Task<Player?> AddPlayerPositionsAsync(int playerId, List<int> positionIds);
     Task<Player?> RemovePlayerPositionsAsync(int playerId, List<int> positionIds);

--- a/the-backfield/Interfaces/IPlayerService.cs
+++ b/the-backfield/Interfaces/IPlayerService.cs
@@ -8,7 +8,7 @@ public interface IPlayerService
     Task<PlayerResponseDTO> GetSinglePlayerAsync(int playerId, string sessionKey);
     Task<PlayerResponseDTO> CreatePlayerAsync(PlayerSubmitDTO playerSubmit);
     Task<PlayerResponseDTO> UpdatePlayerAsync(PlayerSubmitDTO playerSubmit);
-    Task<string?> DeletePlayerAsync(int playerId, int userId);
+    Task<PlayerResponseDTO> DeletePlayerAsync(int playerId, string sessionKey);
     Task<PlayerResponseDTO> AddPlayerPositionsAsync(PlayerPositionSubmitDTO playerPositionSubmit);
     Task<PlayerResponseDTO> RemovePlayerPositionsAsync(PlayerPositionSubmitDTO playerPositionSubmit);
 }

--- a/the-backfield/Interfaces/ITeamRepository.cs
+++ b/the-backfield/Interfaces/ITeamRepository.cs
@@ -9,5 +9,5 @@ public interface ITeamRepository
     Task<Team?> GetSingleTeamAsync(int teamId);
     Task<Team> CreateTeamAsync(TeamSubmitDTO teamSubmit, int userId);
     Task<Team?> UpdateTeamAsync(TeamSubmitDTO teamSubmit);
-    Task<Team> DeleteTeamAsync(int teamId);
+    Task<string?> DeleteTeamAsync(int teamId);
 }

--- a/the-backfield/Interfaces/ITeamService.cs
+++ b/the-backfield/Interfaces/ITeamService.cs
@@ -9,5 +9,5 @@ public interface ITeamService
     Task<TeamResponseDTO> GetSingleTeamAsync(int teamId, string sessionKey);
     Task<TeamResponseDTO> CreateTeamAsync(TeamSubmitDTO teamSubmit);
     Task<TeamResponseDTO> UpdateTeamAsync(TeamSubmitDTO teamSubmit);
-    Task<Team> DeleteTeamAsync(int teamId, int userId);
+    Task<TeamResponseDTO> DeleteTeamAsync(int teamId, string sessionKey);
 }

--- a/the-backfield/Migrations/TheBackfieldDbContextModelSnapshot.cs
+++ b/the-backfield/Migrations/TheBackfieldDbContextModelSnapshot.cs
@@ -34,7 +34,7 @@ namespace the_backfield.Migrations
 
                     b.HasIndex("PositionsId");
 
-                    b.ToTable("PlayerPosition");
+                    b.ToTable("PlayerPosition", (string)null);
                 });
 
             modelBuilder.Entity("TheBackfield.Models.Game", b =>
@@ -75,7 +75,7 @@ namespace the_backfield.Migrations
 
                     b.HasIndex("HomeTeamId");
 
-                    b.ToTable("Games");
+                    b.ToTable("Games", (string)null);
                 });
 
             modelBuilder.Entity("TheBackfield.Models.GameStat", b =>
@@ -148,7 +148,7 @@ namespace the_backfield.Migrations
 
                     b.HasIndex("TeamId");
 
-                    b.ToTable("GameStats");
+                    b.ToTable("GameStats", (string)null);
                 });
 
             modelBuilder.Entity("TheBackfield.Models.Player", b =>
@@ -191,7 +191,7 @@ namespace the_backfield.Migrations
 
                     b.HasIndex("TeamId");
 
-                    b.ToTable("Players");
+                    b.ToTable("Players", (string)null);
                 });
 
             modelBuilder.Entity("TheBackfield.Models.Position", b =>
@@ -212,7 +212,7 @@ namespace the_backfield.Migrations
 
                     b.HasKey("Id");
 
-                    b.ToTable("Positions");
+                    b.ToTable("Positions", (string)null);
 
                     b.HasData(
                         new
@@ -438,7 +438,7 @@ namespace the_backfield.Migrations
 
                     b.HasKey("Id");
 
-                    b.ToTable("Teams");
+                    b.ToTable("Teams", (string)null);
                 });
 
             modelBuilder.Entity("TheBackfield.Models.User", b =>
@@ -469,7 +469,7 @@ namespace the_backfield.Migrations
 
                     b.HasKey("Id");
 
-                    b.ToTable("Users");
+                    b.ToTable("Users", (string)null);
                 });
 
             modelBuilder.Entity("PlayerPosition", b =>

--- a/the-backfield/Repositories/GameRepository.cs
+++ b/the-backfield/Repositories/GameRepository.cs
@@ -59,8 +59,16 @@ public class GameRepository : IGameRepository
         return game;
     }
 
-    public Task<string?> DeleteGameAsync(int gameId, int userId)
+    public async Task<string?> DeleteGameAsync(int gameId)
     {
-        throw new NotImplementedException();
+        Game? game = await _dbContext.Games.FindAsync(gameId);
+        if (game == null)
+        {
+            return "Invalid game id";
+        }
+
+        _dbContext.Games.Remove(game);
+        await _dbContext.SaveChangesAsync();
+        return null;
     }
 }

--- a/the-backfield/Repositories/GameStatRepository.cs
+++ b/the-backfield/Repositories/GameStatRepository.cs
@@ -28,11 +28,6 @@ public class GameStatRepository : IGameStatRepository
         return newGameStat;
     }
 
-    public Task<string?> DeleteGameStatAsync(int gameStatId, int userId)
-    {
-        throw new NotImplementedException();
-    }
-
     public async Task<GameStat?> UpdateGameStatAsync(GameStat updatedGameStat)
     {
         GameStat? gameStat = await _dbContext.GameStats.FindAsync(updatedGameStat.Id);
@@ -58,5 +53,18 @@ public class GameStatRepository : IGameStatRepository
 
         await _dbContext.SaveChangesAsync();
         return gameStat;
+    }
+
+    public async Task<string?> DeleteGameStatAsync(int gameStatId)
+    {
+        GameStat? gameStat = await _dbContext.GameStats.FindAsync(gameStatId);
+        if (gameStat == null)
+        {
+            return "Invalid gameStat Id";
+        }
+
+        _dbContext.GameStats.Remove(gameStat);
+        await _dbContext.SaveChangesAsync();
+        return null;
     }
 }

--- a/the-backfield/Repositories/GameStatRepository.cs
+++ b/the-backfield/Repositories/GameStatRepository.cs
@@ -60,7 +60,7 @@ public class GameStatRepository : IGameStatRepository
         GameStat? gameStat = await _dbContext.GameStats.FindAsync(gameStatId);
         if (gameStat == null)
         {
-            return "Invalid gameStat Id";
+            return "Invalid gameStat id";
         }
 
         _dbContext.GameStats.Remove(gameStat);

--- a/the-backfield/Repositories/PlayerRepository.cs
+++ b/the-backfield/Repositories/PlayerRepository.cs
@@ -22,9 +22,17 @@ public class PlayerRepository : IPlayerRepository
         return newPlayer;
     }
 
-    public Task<string?> DeletePlayerAsync(int playerId, int userId)
+    public async Task<string?> DeletePlayerAsync(int playerId)
     {
-        throw new NotImplementedException();
+        Player? player = await _dbContext.Players.FindAsync(playerId);
+        if (player == null)
+        {
+            return "Invalid player id";
+        }
+
+        _dbContext.Players.Remove(player);
+        await _dbContext.SaveChangesAsync();
+        return null;
     }
 
     public async Task<List<Player>> GetPlayersAsync(int userId)
@@ -64,7 +72,7 @@ public class PlayerRepository : IPlayerRepository
         return updatedPlayer;
     }
 
-    public async Task<Player> SetPlayerPositionsAsync(int playerId, List<int> positionIds)
+    public async Task<Player?> SetPlayerPositionsAsync(int playerId, List<int> positionIds)
     {
         Player? player = await _dbContext.Players
             .Include(p => p.Positions)

--- a/the-backfield/Repositories/TeamRepository.cs
+++ b/the-backfield/Repositories/TeamRepository.cs
@@ -34,9 +34,17 @@ public class TeamRepository : ITeamRepository
         return newTeam;
     }
 
-    public Task<Team> DeleteTeamAsync(int teamId)
+    public async Task<string?> DeleteTeamAsync(int teamId)
     {
-        throw new NotImplementedException();
+        Team? team = await _dbContext.Teams.FindAsync(teamId);
+        if (team == null)
+        {
+            return "Invalid team id";
+        }
+
+        _dbContext.Teams.Remove(team);
+        await _dbContext.SaveChangesAsync();
+        return null;
     }
 
     public async Task<Team?> GetSingleTeamAsync(int teamId)

--- a/the-backfield/Services/GameService.cs
+++ b/the-backfield/Services/GameService.cs
@@ -48,9 +48,17 @@ public class GameService : IGameService
         return new GameResponseDTO { Game = await _gameRepository.CreateGameAsync(gameSubmit.MapToGame(user.Id)) };
     }
 
-    public async Task<string?> DeleteGameAsync(int gameId, int userId)
+    public async Task<GameResponseDTO> DeleteGameAsync(int gameId, string sessionKey)
     {
-        return await _gameRepository.DeleteGameAsync(gameId, userId);
+        User? user = await _userRepository.GetUserBySessionKeyAsync(sessionKey);
+        Game? game = await _gameRepository.GetSingleGameAsync(gameId);
+        GameResponseDTO gameCheck = SessionKeyClient.VerifyAccess(sessionKey, user, game);
+        if (gameCheck.Error)
+        {
+            return gameCheck;
+        }
+
+        return new GameResponseDTO { ErrorMessage = await _gameRepository.DeleteGameAsync(gameId) };
     }
 
     public async Task<GameResponseDTO> GetAllGamesAsync(string sessionKey)

--- a/the-backfield/Services/GameStatService.cs
+++ b/the-backfield/Services/GameStatService.cs
@@ -50,9 +50,17 @@ public class GameStatService : IGameStatService
         return new GameStatResponseDTO { GameStat = await _gameStatRepository.CreateGameStatAsync(gameStatSubmit.MapToGameStat(user.Id)) };
     }
 
-    public async Task<string?> DeleteGameStatAsync(int gameStatId, int userId)
+    public async Task<GameStatResponseDTO> DeleteGameStatAsync(int gameStatId, string sessionKey)
     {
-        return await _gameStatRepository.DeleteGameStatAsync(gameStatId, userId);
+        User? user = await _userRepository.GetUserBySessionKeyAsync(sessionKey);
+        GameStat? gameStat = await _gameStatRepository.GetSingleGameStatAsync(gameStatId);
+        GameStatResponseDTO gameStatCheck = SessionKeyClient.VerifyAccess(sessionKey, user, gameStat);
+        if (gameStatCheck.Error)
+        {
+            return gameStatCheck;
+        }
+
+        return new GameStatResponseDTO { ErrorMessage = await _gameStatRepository.DeleteGameStatAsync(gameStatId) };
     }
 
     public async Task<GameStatResponseDTO> UpdateGameStatAsync(GameStatSubmitDTO gameStatSubmit)

--- a/the-backfield/Services/PlayerService.cs
+++ b/the-backfield/Services/PlayerService.cs
@@ -39,9 +39,17 @@ public class PlayerService : IPlayerService
         return new PlayerResponseDTO { Player = await _playerRepository.SetPlayerPositionsAsync(addedPlayer.Id, playerSubmit.PositionIds) };
     }
 
-    public async Task<string?> DeletePlayerAsync(int playerId, int userId)
+    public async Task<PlayerResponseDTO> DeletePlayerAsync(int playerId, string sessionKey)
     {
-        return await _playerRepository.DeletePlayerAsync(playerId, userId);
+        User? user = await _userRepository.GetUserBySessionKeyAsync(sessionKey);
+        Player? player = await _playerRepository.GetSinglePlayerAsync(playerId);
+        PlayerResponseDTO playerCheck = SessionKeyClient.VerifyAccess(sessionKey, user, player);
+        if (playerCheck.Error)
+        {
+            return playerCheck;
+        }
+
+        return new PlayerResponseDTO { ErrorMessage = await _playerRepository.DeletePlayerAsync(playerId) };
     }
 
     public async Task<PlayerResponseDTO> GetPlayersAsync(string sessionKey)

--- a/the-backfield/Services/TeamService.cs
+++ b/the-backfield/Services/TeamService.cs
@@ -27,9 +27,17 @@ public class TeamService : ITeamService
         return new TeamResponseDTO { Team = newTeam };
     }
 
-    public async Task<Team> DeleteTeamAsync(int teamId, int userId)
+    public async Task<TeamResponseDTO> DeleteTeamAsync(int teamId, string sessionKey)
     {
-        return await _teamRepository.DeleteTeamAsync(teamId);
+        User? user = await _userRepository.GetUserBySessionKeyAsync(sessionKey);
+        Team? team = await _teamRepository.GetSingleTeamAsync(teamId);
+        TeamResponseDTO teamCheck = SessionKeyClient.VerifyAccess(sessionKey, user, team);
+        if (teamCheck.Error)
+        {
+            return teamCheck;
+        }
+
+        return new TeamResponseDTO { ErrorMessage = await _teamRepository.DeleteTeamAsync(teamId) };
     }
 
     public async Task<TeamResponseDTO> GetSingleTeamAsync(int teamId, string sessionKey)


### PR DESCRIPTION
Added delete functionality/APIs for Teams, Players, Games, and GameStats

Repository delete calls return a nullable string, which gets set to the ErrorMessage on the ResponseDTO in the Service. If there is an error in the repository, will thus indicate an error. Else it returns null to ResponseDTO.ErrorMessage, and the Endpoint returns a 204.