### PR TITLE
Play GET single / CREATE / DELETE

### DIFF
--- a/the-backfield/DTOs/GameSubmitDTO.cs
+++ b/the-backfield/DTOs/GameSubmitDTO.cs
@@ -12,8 +12,8 @@ public class GameSubmitDTO
     public int AwayTeamId { get; set; } = 0;
     public int? AwayTeamScore { get; set; }
     public DateTime? GameStart { get; set; }
-    public int? GamePeriods { get; set; }
-    public int? PeriodLength { get; set; }
+    public int? GamePeriods { get; set; } = 4;
+    public int? PeriodLength { get; set; } = 900;
     public string? SessionKey { get; set; }
     /// <summary>
     /// 

--- a/the-backfield/DTOs/PlaySubmitDTO.cs
+++ b/the-backfield/DTOs/PlaySubmitDTO.cs
@@ -10,12 +10,15 @@ namespace TheBackfield.DTOs
         public int PrevPlayId { get; set; } // Reserve 1 for Game Start
         [Required]
         public int GameId { get; set; }
+        [Required]
+        public int TeamId { get; set; }
         public int? FieldPositionStart { get; set; } = null;
         public int? FieldPositionEnd { get; set; } = null;
         public int Down { get; set; } = 0;
         public int? ToGain { get; set; } = null;
         public int? ClockStart { get; set; } = null;
         public int? ClockEnd { get; set; } = null;
+        public int? GamePeriod { get; set; } = null;
         public string Notes { get; set; } = "";
         public int? PasserId { get; set; } = null;
         public int? ReceiverId { get; set; } = null;

--- a/the-backfield/Data/PlayData.cs
+++ b/the-backfield/Data/PlayData.cs
@@ -1,0 +1,12 @@
+﻿using TheBackfield.Models;
+
+namespace TheBackfield.Data
+{
+    public class PlayData
+    {
+        public static List<Play> Plays = new()
+        {
+            new() { Id = -1, Notes = "Game Start" }
+        };
+    }
+}

--- a/the-backfield/Data/TheBackfieldDbContext.cs
+++ b/the-backfield/Data/TheBackfieldDbContext.cs
@@ -52,6 +52,7 @@ public class TheBackfieldDbContext : DbContext
             .HasForeignKey(gs => gs.PlayerId);
 
         modelBuilder.Entity<Penalty>().HasData(PenaltyData.Penalties);
+        modelBuilder.Entity<Play>().HasData(PlayData.Plays);
         modelBuilder.Entity<Position>().HasData(PositionData.Positions);
     }
 }

--- a/the-backfield/Endpoints/PlayEndpoints.cs
+++ b/the-backfield/Endpoints/PlayEndpoints.cs
@@ -22,5 +22,31 @@ public static class PlayEndpoints
         })
             .WithOpenApi()
             .Produces<Play>(StatusCodes.Status200OK);
+
+        group.MapPost("/plays", async (IPlayService playService, PlaySubmitDTO playSubmit) =>
+        {
+            PlayResponseDTO response = await playService.CreatePlayAsync(playSubmit);
+            if (response.Error || response.Play == null)
+            {
+                return response.ThrowError();
+            }
+
+            return Results.Created($"/plays/{response.Play.Id}", response.Play);
+        })
+            .WithOpenApi()
+            .Produces<Play>(StatusCodes.Status201Created);
+
+        group.MapDelete("/plays/{playId}", async (IPlayService playService, int playId, string sessionKey) =>
+        {
+            PlayResponseDTO response = await playService.DeletePlayAsync(playId, sessionKey);
+            if (response.Error)
+            {
+                return response.ThrowError();
+            }
+
+            return Results.NoContent();
+        })
+            .WithOpenApi()
+            .Produces(StatusCodes.Status204NoContent);
     }
 }

--- a/the-backfield/Endpoints/PlayEndpoints.cs
+++ b/the-backfield/Endpoints/PlayEndpoints.cs
@@ -1,3 +1,5 @@
+using TheBackfield.DTOs;
+using TheBackfield.Interfaces;
 using TheBackfield.Models;
 
 namespace TheBackfield.Endpoints;
@@ -7,5 +9,18 @@ public static class PlayEndpoints
     public static void MapPlayEndpoints(this IEndpointRouteBuilder routes)
     {
         var group = routes.MapGroup("").WithTags(nameof(Play));
+
+        group.MapGet("/plays/{playId}", async (IPlayService playService, int playId, string sessionKey) =>
+        {
+            PlayResponseDTO response = await playService.GetSinglePlayAsync(playId, sessionKey);
+            if (response.Error)
+            {
+                return response.ThrowError();
+            };
+
+            return Results.Ok(response.Play);
+        })
+            .WithOpenApi()
+            .Produces<Play>(StatusCodes.Status200OK);
     }
 }

--- a/the-backfield/Migrations/20241208011222_InitialPlay.Designer.cs
+++ b/the-backfield/Migrations/20241208011222_InitialPlay.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TheBackfield.Data;
@@ -11,9 +12,10 @@ using TheBackfield.Data;
 namespace the_backfield.Migrations
 {
     [DbContext(typeof(TheBackfieldDbContext))]
-    partial class TheBackfieldDbContextModelSnapshot : ModelSnapshot
+    [Migration("20241208011222_InitialPlay")]
+    partial class InitialPlay
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/the-backfield/Migrations/20241208011222_InitialPlay.cs
+++ b/the-backfield/Migrations/20241208011222_InitialPlay.cs
@@ -1,0 +1,66 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace the_backfield.Migrations
+{
+    public partial class InitialPlay : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Plays_Games_GameId",
+                table: "Plays");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "GameId",
+                table: "Plays",
+                type: "integer",
+                nullable: true,
+                oldClrType: typeof(int),
+                oldType: "integer");
+
+            migrationBuilder.InsertData(
+                table: "Plays",
+                columns: new[] { "Id", "ClockEnd", "ClockStart", "Down", "FieldPositionEnd", "FieldPositionStart", "GameId", "Notes", "PrevPlayId", "ToGain" },
+                values: new object[] { -1, null, null, 0, null, null, null, "Game Start", null, null });
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Plays_Games_GameId",
+                table: "Plays",
+                column: "GameId",
+                principalTable: "Games",
+                principalColumn: "Id");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Plays_Games_GameId",
+                table: "Plays");
+
+            migrationBuilder.DeleteData(
+                table: "Plays",
+                keyColumn: "Id",
+                keyValue: -1);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "GameId",
+                table: "Plays",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0,
+                oldClrType: typeof(int),
+                oldType: "integer",
+                oldNullable: true);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Plays_Games_GameId",
+                table: "Plays",
+                column: "GameId",
+                principalTable: "Games",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}

--- a/the-backfield/Migrations/20241208082219_PlayGamePeriod.Designer.cs
+++ b/the-backfield/Migrations/20241208082219_PlayGamePeriod.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TheBackfield.Data;
@@ -11,9 +12,10 @@ using TheBackfield.Data;
 namespace the_backfield.Migrations
 {
     [DbContext(typeof(TheBackfieldDbContext))]
-    partial class TheBackfieldDbContextModelSnapshot : ModelSnapshot
+    [Migration("20241208082219_PlayGamePeriod")]
+    partial class PlayGamePeriod
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -611,9 +613,6 @@ namespace the_backfield.Migrations
                     b.Property<int?>("PrevPlayId")
                         .HasColumnType("integer");
 
-                    b.Property<int?>("TeamId")
-                        .HasColumnType("integer");
-
                     b.Property<int?>("ToGain")
                         .HasColumnType("integer");
 
@@ -622,8 +621,6 @@ namespace the_backfield.Migrations
                     b.HasIndex("GameId");
 
                     b.HasIndex("PrevPlayId");
-
-                    b.HasIndex("TeamId");
 
                     b.ToTable("Plays");
 
@@ -1472,15 +1469,9 @@ namespace the_backfield.Migrations
                         .WithMany()
                         .HasForeignKey("PrevPlayId");
 
-                    b.HasOne("TheBackfield.Models.Team", "Team")
-                        .WithMany()
-                        .HasForeignKey("TeamId");
-
                     b.Navigation("Game");
 
                     b.Navigation("PrevPlay");
-
-                    b.Navigation("Team");
                 });
 
             modelBuilder.Entity("TheBackfield.Models.PlayEntities.Conversion", b =>

--- a/the-backfield/Migrations/20241208082219_PlayGamePeriod.cs
+++ b/the-backfield/Migrations/20241208082219_PlayGamePeriod.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace the_backfield.Migrations
+{
+    public partial class PlayGamePeriod : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "GamePeriod",
+                table: "Plays",
+                type: "integer",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "GamePeriod",
+                table: "Plays");
+        }
+    }
+}

--- a/the-backfield/Migrations/20241208082940_PlayTeamId.Designer.cs
+++ b/the-backfield/Migrations/20241208082940_PlayTeamId.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TheBackfield.Data;
@@ -11,9 +12,10 @@ using TheBackfield.Data;
 namespace the_backfield.Migrations
 {
     [DbContext(typeof(TheBackfieldDbContext))]
-    partial class TheBackfieldDbContextModelSnapshot : ModelSnapshot
+    [Migration("20241208082940_PlayTeamId")]
+    partial class PlayTeamId
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/the-backfield/Migrations/20241208082940_PlayTeamId.cs
+++ b/the-backfield/Migrations/20241208082940_PlayTeamId.cs
@@ -1,0 +1,45 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace the_backfield.Migrations
+{
+    public partial class PlayTeamId : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "TeamId",
+                table: "Plays",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Plays_TeamId",
+                table: "Plays",
+                column: "TeamId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Plays_Teams_TeamId",
+                table: "Plays",
+                column: "TeamId",
+                principalTable: "Teams",
+                principalColumn: "Id");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Plays_Teams_TeamId",
+                table: "Plays");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Plays_TeamId",
+                table: "Plays");
+
+            migrationBuilder.DropColumn(
+                name: "TeamId",
+                table: "Plays");
+        }
+    }
+}

--- a/the-backfield/Models/Game.cs
+++ b/the-backfield/Models/Game.cs
@@ -64,8 +64,8 @@ public class Game : IGame
         }
     }
     public DateTime GameStart { get; set; }
-    public int GamePeriods { get; set; }
-    public int PeriodLength { get; set; }
+    public int GamePeriods { get; set; } = 4;
+    public int PeriodLength { get; set; } = 900;
     [JsonIgnore]
     public List<GameStat> GameStats { get; set; } = [];
     public List<Play> Plays { get; set; } = [];

--- a/the-backfield/Models/Play.cs
+++ b/the-backfield/Models/Play.cs
@@ -1,5 +1,4 @@
-﻿using System.ComponentModel.DataAnnotations;
-using TheBackfield.Models.PlayEntities;
+﻿using TheBackfield.Models.PlayEntities;
 
 namespace TheBackfield.Models
 {
@@ -10,12 +9,15 @@ namespace TheBackfield.Models
         public Play? PrevPlay { get; set; }
         public int? GameId { get; set; } = null;
         public Game Game { get; set; }
+        public int? TeamId { get; set; } = null;
+        public Team Team { get; set; }
         public int? FieldPositionStart { get; set; } = null;
         public int? FieldPositionEnd { get; set; } = null;
         public int Down { get; set; } = 0;
         public int? ToGain { get; set; } = null;
         public int? ClockStart { get; set; } = null;
         public int? ClockEnd { get; set; } = null;
+        public int? GamePeriod { get; set; } = null;
         public string Notes { get; set; } = "";
         public Pass? Pass { get; set; }
         public Rush? Rush { get; set; }

--- a/the-backfield/Models/Play.cs
+++ b/the-backfield/Models/Play.cs
@@ -8,8 +8,7 @@ namespace TheBackfield.Models
         public int Id { get; set; }
         public int? PrevPlayId { get; set; } = null;
         public Play? PrevPlay { get; set; }
-        [Required]
-        public int GameId { get; set; }
+        public int? GameId { get; set; } = null;
         public Game Game { get; set; }
         public int? FieldPositionStart { get; set; } = null;
         public int? FieldPositionEnd { get; set; } = null;

--- a/the-backfield/Repositories/PlayRepository.cs
+++ b/the-backfield/Repositories/PlayRepository.cs
@@ -1,4 +1,6 @@
-﻿using TheBackfield.DTOs;
+﻿using Microsoft.EntityFrameworkCore;
+using TheBackfield.Data;
+using TheBackfield.DTOs;
 using TheBackfield.Interfaces;
 using TheBackfield.Models;
 
@@ -6,6 +8,13 @@ namespace TheBackfield.Repositories
 {
     public class PlayRepository : IPlayRepository
     {
+        private readonly TheBackfieldDbContext _dbContext;
+
+        public PlayRepository(TheBackfieldDbContext context)
+        {
+            _dbContext = context;
+        }
+
         public Task<Play?> CreatePlayAsync(PlaySubmitDTO playSubmit)
         {
             throw new NotImplementedException();
@@ -16,9 +25,28 @@ namespace TheBackfield.Repositories
             throw new NotImplementedException();
         }
 
-        public Task<Play?> GetSinglePlayAsync(int playId)
+        public async Task<Play?> GetSinglePlayAsync(int playId)
         {
-            throw new NotImplementedException();
+            return await _dbContext.Plays
+                .AsNoTracking()
+                .Include(g => g.PrevPlay)
+                .Include(p => p.Game)
+                .Include(g => g.Pass)
+                    .ThenInclude(p => p.Passer)
+                .Include(g => g.Rush)
+                .Include(g => g.Tacklers)
+                .Include(g => g.PassDefenders)
+                .Include(g => g.Kickoff)
+                .Include(g => g.Punt)
+                .Include(g => g.FieldGoal)
+                .Include(g => g.ExtraPoint)
+                .Include(g => g.Conversion)
+                .Include(g => g.Fumbles)
+                .Include(g => g.Interception)
+                .Include(g => g.KickBlock)
+                .Include(g => g.Laterals)
+                .Include(g => g.Penalties)
+                .SingleOrDefaultAsync(p => p.Id == playId);
         }
 
         public Task<Play?> UpdatePlayAsync(PlaySubmitDTO playSubmit)

--- a/the-backfield/Services/PlayService.cs
+++ b/the-backfield/Services/PlayService.cs
@@ -1,10 +1,21 @@
 ﻿using TheBackfield.DTOs;
 using TheBackfield.Interfaces;
+using TheBackfield.Models;
+using TheBackfield.Utilities;
 
 namespace TheBackfield.Services
 {
     public class PlayService : IPlayService
     {
+        private readonly IPlayRepository _playRepository;
+        private readonly IUserRepository _userRepository;
+
+        public PlayService(IPlayRepository playRepository, IUserRepository userRepository)
+        {
+            _playRepository = playRepository;
+            _userRepository = userRepository;
+        }
+
         public Task<PlayResponseDTO> CreatePlayAsync(PlaySubmitDTO playSubmit)
         {
             throw new NotImplementedException();
@@ -15,9 +26,11 @@ namespace TheBackfield.Services
             throw new NotImplementedException();
         }
 
-        public Task<PlayResponseDTO> GetSinglePlayAsync(int playId, string sessionKey)
+        public async Task<PlayResponseDTO> GetSinglePlayAsync(int playId, string sessionKey)
         {
-            throw new NotImplementedException();
+            User? user = await _userRepository.GetUserBySessionKeyAsync(sessionKey);
+            Play? play = await _playRepository.GetSinglePlayAsync(playId);
+            return SessionKeyClient.VerifyAccess(sessionKey, user, play);
         }
 
         public Task<PlayResponseDTO> UpdatePlayAsync(PlaySubmitDTO playSubmit)

--- a/the-backfield/Services/PlayService.cs
+++ b/the-backfield/Services/PlayService.cs
@@ -8,26 +8,91 @@ namespace TheBackfield.Services
     public class PlayService : IPlayService
     {
         private readonly IPlayRepository _playRepository;
+        private readonly IGameRepository _gameRepository;
         private readonly IUserRepository _userRepository;
 
-        public PlayService(IPlayRepository playRepository, IUserRepository userRepository)
+        public PlayService(
+            IPlayRepository playRepository,
+            IGameRepository gameRepository,
+            IUserRepository userRepository
+            )
         {
             _playRepository = playRepository;
+            _gameRepository = gameRepository;
             _userRepository = userRepository;
         }
 
-        public Task<PlayResponseDTO> CreatePlayAsync(PlaySubmitDTO playSubmit)
+        public async Task<PlayResponseDTO> CreatePlayAsync(PlaySubmitDTO playSubmit)
         {
-            throw new NotImplementedException();
+            User? user = await _userRepository.GetUserBySessionKeyAsync(playSubmit.SessionKey);
+            Game? game = await _gameRepository.GetSingleGameAsync(playSubmit.GameId);
+            GameResponseDTO gameCheck = SessionKeyClient.VerifyAccess(playSubmit.SessionKey, user, game);
+            if (gameCheck.Error)
+            {
+                return gameCheck.CastTo<PlayResponseDTO>();
+            }
+
+            if (playSubmit.TeamId != game.HomeTeamId && playSubmit.TeamId != game.AwayTeamId)
+            {
+                return new PlayResponseDTO { ErrorMessage = $"Invalid team id, must correspond with home team (id #{game.HomeTeamId}) or away team (id #{game.AwayTeamId}) for this game" };
+            }
+
+            Play? previousPlay = await _playRepository.GetSinglePlayAsync(playSubmit.PrevPlayId);
+
+            if (previousPlay == null)
+            {
+                return new PlayResponseDTO { ErrorMessage = "Invalid previous play id" };
+            }
+
+            if ((Math.Abs(playSubmit.FieldPositionStart ?? 0) > 50) || (Math.Abs(playSubmit.FieldPositionEnd ?? 0) > 50)
+                || (Math.Abs(playSubmit.ToGain ?? 0) > 50))
+            {
+                return new PlayResponseDTO { ErrorMessage = "FieldPositionStart/End and ToGain yardage values must be between -50 (home team endzone) and 50 (away team endzone)" };
+            }
+
+            if (playSubmit.Down < 0 || playSubmit.Down > 4)
+            {
+                return new PlayResponseDTO { ErrorMessage = "Down must be between 0 (used for non-scrimmage plays) and 4" };
+            }
+
+            if ((playSubmit.ClockStart ?? 0) > game.PeriodLength || (playSubmit.ClockStart ?? 0) < 0
+                || (playSubmit.ClockEnd ?? 0) > game.PeriodLength || (playSubmit.ClockEnd ?? 0) < 0)
+            {
+                return new PlayResponseDTO { ErrorMessage = $"ClockStart/End must be times in seconds between game's PeriodLength ({game.PeriodLength} seconds) and 0 (gamePeriod end)" };
+            }
+
+            if (playSubmit.ClockStart < playSubmit.ClockEnd)
+            {
+                return new PlayResponseDTO { ErrorMessage = "ClockStart must be greater than or equal to ClockEnd" };
+            }
+
+            if ((playSubmit.GamePeriod ?? 1) < 1 || (playSubmit.GamePeriod ?? 1) > game.GamePeriods)
+            {
+                return new PlayResponseDTO { ErrorMessage = $"GamePeriod must be a number between 1 and the total number of game periods for this game ({game.GamePeriods})" };
+            }
+
+            return new PlayResponseDTO { Play = await _playRepository.CreatePlayAsync(playSubmit) };
         }
 
-        public Task<PlayResponseDTO> DeletePlayAsync(int playId, string sessionKey)
+        public async Task<PlayResponseDTO> DeletePlayAsync(int playId, string sessionKey)
         {
-            throw new NotImplementedException();
+            User? user = await _userRepository.GetUserBySessionKeyAsync(sessionKey);
+            Play? play = await _playRepository.GetSinglePlayAsync(playId);
+            PlayResponseDTO playCheck = SessionKeyClient.VerifyAccess(sessionKey, user, play);
+            if (playCheck.Error)
+            {
+                return playCheck;
+            }
+
+            return new PlayResponseDTO { ErrorMessage = await _playRepository.DeletePlayAsync(playId) };
         }
 
         public async Task<PlayResponseDTO> GetSinglePlayAsync(int playId, string sessionKey)
         {
+            if (playId <= 0)
+            {
+                return new PlayResponseDTO { Forbidden = true };
+            }
             User? user = await _userRepository.GetUserBySessionKeyAsync(sessionKey);
             Play? play = await _playRepository.GetSinglePlayAsync(playId);
             return SessionKeyClient.VerifyAccess(sessionKey, user, play);

--- a/the-backfield/Utilities/SessionKeyClient.cs
+++ b/the-backfield/Utilities/SessionKeyClient.cs
@@ -119,5 +119,22 @@ namespace TheBackfield.Utilities
             }
             return new GameStatResponseDTO { GameStat = gameStat };
         }
+
+        public static PlayResponseDTO VerifyAccess(string sessionKey, User? user, Play? play)
+        {
+            if (play == null)
+            {
+                return new PlayResponseDTO { NotFound = true, ErrorMessage = "Invalid play id" };
+            }
+            if (user == null || user.SessionKey != sessionKey)
+            {
+                return new PlayResponseDTO { Unauthorized = true, ErrorMessage = "Invalid session key" };
+            }
+            if (play.Game == null || play.Game.UserId != user.Id)
+            {
+                return new PlayResponseDTO { Forbidden = true, ErrorMessage = "User lacks permissions to access this game" };
+            }
+            return new PlayResponseDTO { Play = play };
+        }
     }
 }


### PR DESCRIPTION
Added endpoints, service, repository functionality for Get Single Play, Create Play (base Play values only), and Delete Play

Create and Delete correspondingly insert/remove Play from play stream by adjusting PrevPlayIds on neighboring plays

Added GamePeriod, TeamId to Play and PlaySubmitDTO

Added initial Play seed data to index -1, used to begin a play stream for a game

Added VerifyAccess method for Play check

**Requires database update on merge**