### PR TITLE
Create a Pass, no delete on player delete

### DIFF
--- a/the-backfield/Data/TheBackfieldDbContext.cs
+++ b/the-backfield/Data/TheBackfieldDbContext.cs
@@ -51,6 +51,15 @@ public class TheBackfieldDbContext : DbContext
             .WithMany()
             .HasForeignKey(gs => gs.PlayerId);
 
+        modelBuilder.Entity<Pass>()
+            .HasOne(p => p.Passer)
+            .WithMany()
+            .OnDelete(DeleteBehavior.SetNull);
+        modelBuilder.Entity<Pass>()
+            .HasOne(p => p.Receiver)
+            .WithMany()
+            .OnDelete(DeleteBehavior.SetNull);
+
         modelBuilder.Entity<Penalty>().HasData(PenaltyData.Penalties);
         modelBuilder.Entity<Play>().HasData(PlayData.Plays);
         modelBuilder.Entity<Position>().HasData(PositionData.Positions);

--- a/the-backfield/Interfaces/PlayEntities/IPassRepository.cs
+++ b/the-backfield/Interfaces/PlayEntities/IPassRepository.cs
@@ -5,8 +5,8 @@ namespace TheBackfield.Interfaces.PlayEntities;
 
 public interface IPassRepository
 {
-    Task<Pass?> GetSinglePassAsync(int conversionId);
+    Task<Pass?> GetSinglePassAsync(int passId);
     Task<Pass?> CreatePassAsync(PlaySubmitDTO playSubmit);
     Task<Pass?> UpdatePassAsync(PlaySubmitDTO playSubmit);
-    Task<bool> DeletePassAsync(int conversionId);
+    Task<bool> DeletePassAsync(int passId);
 }

--- a/the-backfield/Migrations/20241210003758_PassDeleteBehavior.Designer.cs
+++ b/the-backfield/Migrations/20241210003758_PassDeleteBehavior.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TheBackfield.Data;
@@ -11,9 +12,10 @@ using TheBackfield.Data;
 namespace the_backfield.Migrations
 {
     [DbContext(typeof(TheBackfieldDbContext))]
-    partial class TheBackfieldDbContextModelSnapshot : ModelSnapshot
+    [Migration("20241210003758_PassDeleteBehavior")]
+    partial class PassDeleteBehavior
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/the-backfield/Migrations/20241210003758_PassDeleteBehavior.cs
+++ b/the-backfield/Migrations/20241210003758_PassDeleteBehavior.cs
@@ -1,0 +1,80 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace the_backfield.Migrations
+{
+    public partial class PassDeleteBehavior : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Passes_Players_PasserId",
+                table: "Passes");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Passes_Players_ReceiverId",
+                table: "Passes");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "PasserId",
+                table: "Passes",
+                type: "integer",
+                nullable: true,
+                oldClrType: typeof(int),
+                oldType: "integer");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Passes_Players_PasserId",
+                table: "Passes",
+                column: "PasserId",
+                principalTable: "Players",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.SetNull);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Passes_Players_ReceiverId",
+                table: "Passes",
+                column: "ReceiverId",
+                principalTable: "Players",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.SetNull);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Passes_Players_PasserId",
+                table: "Passes");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Passes_Players_ReceiverId",
+                table: "Passes");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "PasserId",
+                table: "Passes",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0,
+                oldClrType: typeof(int),
+                oldType: "integer",
+                oldNullable: true);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Passes_Players_PasserId",
+                table: "Passes",
+                column: "PasserId",
+                principalTable: "Players",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Passes_Players_ReceiverId",
+                table: "Passes",
+                column: "ReceiverId",
+                principalTable: "Players",
+                principalColumn: "Id");
+        }
+    }
+}

--- a/the-backfield/Models/PlayEntities/Pass.cs
+++ b/the-backfield/Models/PlayEntities/Pass.cs
@@ -8,10 +8,9 @@ namespace TheBackfield.Models.PlayEntities
         [Required]
         public int PlayId { get; set; }
         public Play Play { get; set; }
-        [Required]
-        public int PasserId { get; set; }
-        public Player Passer { get; set; }
-        public int? ReceiverId { get; set; }
+        public int? PasserId { get; set; } = null;
+        public Player? Passer { get; set; }
+        public int? ReceiverId { get; set; } = null;
         public Player? Receiver { get; set; }
         public bool Completion { get; set; } = false;
     }

--- a/the-backfield/Repositories/PlayRepository.cs
+++ b/the-backfield/Repositories/PlayRepository.cs
@@ -23,6 +23,7 @@ namespace TheBackfield.Repositories
             {
                 PrevPlayId = playSubmit.PrevPlayId,
                 GameId = playSubmit.GameId,
+                TeamId = playSubmit.TeamId,
                 FieldPositionStart = playSubmit.FieldPositionStart,
                 FieldPositionEnd = playSubmit.FieldPositionEnd,
                 Down = playSubmit.Down,


### PR DESCRIPTION
Added functionality to PassRepository for CreatePassAsync, and GetSinglePassAsync

Added functionality to PlayService to validate PlayerId, ReceiverId data and create a Pass with newly created Play, if necessary

Changed Pass foreign key delete behavior to maintain Pass entity even if the Passer or Receiver are deleted from the database (still removed on deletion of Play)

Pull requires new database update