### PR TITLE
Kickoff create/read

### DIFF
--- a/the-backfield/Models/PlayEntities/Kickoff.cs
+++ b/the-backfield/Models/PlayEntities/Kickoff.cs
@@ -10,9 +10,9 @@ namespace TheBackfield.Models.PlayEntities
         public Play Play { get; set; }
         public int? KickerId { get; set; } = null;
         public Player? Kicker { get; set; }
-        public int? ReturnerId { get; set; }
+        public int? ReturnerId { get; set; } = null;
         public Player? Returner { get; set; }
-        public int FieldedAt { get; set; }
+        public int? FieldedAt { get; set; } = null;
         public bool Touchback { get; set; }
     }
 }

--- a/the-backfield/Repositories/PlayEntities/KickoffRepository.cs
+++ b/the-backfield/Repositories/PlayEntities/KickoffRepository.cs
@@ -1,14 +1,59 @@
+using Microsoft.EntityFrameworkCore;
+using TheBackfield.Data;
 using TheBackfield.DTOs;
 using TheBackfield.Interfaces.PlayEntities;
+using TheBackfield.Models;
 using TheBackfield.Models.PlayEntities;
 
 namespace TheBackfield.Repositories.PlayEntities;
 
 public class KickoffRepository : IKickoffRepository
 {
-    public Task<Kickoff?> CreateKickoffAsync(PlaySubmitDTO playSubmit)
+    private readonly TheBackfieldDbContext _dbContext;
+    public KickoffRepository(TheBackfieldDbContext context)
     {
-        throw new NotImplementedException();
+        _dbContext = context;
+    }
+
+    public async Task<Kickoff?> CreateKickoffAsync(PlaySubmitDTO playSubmit)
+    {
+        Play? play = await _dbContext.Plays.FindAsync(playSubmit.Id);
+        if (play == null)
+        {
+            return null;
+        }
+
+        if (playSubmit.KickerId != null)
+        {
+            Player? kicker = await _dbContext.Players.FindAsync(playSubmit.KickerId);
+            if (kicker == null)
+            {
+                return null;
+            }
+        }
+
+        if (playSubmit.KickReturnerId != null)
+        {
+            Player? returner = await _dbContext.Players.FindAsync(playSubmit.KickReturnerId);
+            if (returner == null)
+            {
+                return null;
+            }
+        }
+
+        Kickoff newKickoff = new()
+        {
+            PlayId = playSubmit.Id,
+            KickerId = playSubmit.KickerId,
+            ReturnerId = playSubmit.KickReturnerId,
+            FieldedAt = playSubmit.KickFieldedAt,
+            Touchback = playSubmit.KickTouchback
+        };
+
+        _dbContext.Kickoffs.Add(newKickoff);
+        await _dbContext.SaveChangesAsync();
+
+        return newKickoff;
     }
 
     public Task<bool> DeleteKickoffAsync(int kickoffId)
@@ -16,9 +61,9 @@ public class KickoffRepository : IKickoffRepository
         throw new NotImplementedException();
     }
 
-    public Task<Kickoff?> GetSingleKickoffAsync(int kickoffId)
+    public async Task<Kickoff?> GetSingleKickoffAsync(int kickoffId)
     {
-        throw new NotImplementedException();
+        return await _dbContext.Kickoffs.AsNoTracking().SingleOrDefaultAsync(k => k.Id == kickoffId);
     }
 
     public Task<Kickoff?> UpdateKickoffAsync(PlaySubmitDTO playSubmit)


### PR DESCRIPTION
Address:
- #60 

Add functionality to KickoffRepository:CreateKickoffAsync(), ReadSingleKickoffAsync()

Add functionality to PlayService:CreatePlayAsync() to validate Kickoff data and create a Kickoff when necessary

Kickoffs cannot be created on plays with pass, rush, field goal, punt, interception or pass defense entities
Kickoff == true automatically sets Down = 0