### PR TITLE
Create Punt and FieldGoal

### DIFF
--- a/the-backfield/Repositories/PlayEntities/FieldGoalRepository.cs
+++ b/the-backfield/Repositories/PlayEntities/FieldGoalRepository.cs
@@ -1,14 +1,50 @@
+using Microsoft.EntityFrameworkCore;
+using TheBackfield.Data;
 using TheBackfield.DTOs;
 using TheBackfield.Interfaces.PlayEntities;
+using TheBackfield.Models;
 using TheBackfield.Models.PlayEntities;
 
 namespace TheBackfield.Repositories.PlayEntities;
 
 public class FieldGoalRepository : IFieldGoalRepository
 {
-    public Task<FieldGoal?> CreateFieldGoalAsync(PlaySubmitDTO playSubmit)
+    private readonly TheBackfieldDbContext _dbContext;
+
+    public FieldGoalRepository(TheBackfieldDbContext context)
     {
-        throw new NotImplementedException();
+        _dbContext = context;
+    }
+
+    public async Task<FieldGoal?> CreateFieldGoalAsync(PlaySubmitDTO playSubmit)
+    {
+        Play? play = await _dbContext.Plays.FindAsync(playSubmit.Id);
+        if (play == null)
+        {
+            return null;
+        }
+
+        if (playSubmit.KickerId != null)
+        {
+            Player? kicker = await _dbContext.Players.FindAsync(playSubmit.KickerId);
+            if (kicker == null)
+            {
+                return null;
+            }
+        }
+
+        FieldGoal newFieldGoal = new()
+        {
+            PlayId = playSubmit.Id,
+            KickerId = playSubmit.KickerId,
+            Good = playSubmit.KickGood,
+            Fake = playSubmit.KickFake
+        };
+
+        _dbContext.FieldGoals.Add(newFieldGoal);
+        await _dbContext.SaveChangesAsync();
+
+        return newFieldGoal;
     }
 
     public Task<bool> DeleteFieldGoalAsync(int fieldGoalId)
@@ -16,9 +52,9 @@ public class FieldGoalRepository : IFieldGoalRepository
         throw new NotImplementedException();
     }
 
-    public Task<FieldGoal?> GetSingleFieldGoalAsync(int fieldGoalId)
+    public async Task<FieldGoal?> GetSingleFieldGoalAsync(int fieldGoalId)
     {
-        throw new NotImplementedException();
+        return await _dbContext.FieldGoals.AsNoTracking().SingleOrDefaultAsync(fg => fg.Id == fieldGoalId);
     }
 
     public Task<FieldGoal?> UpdateFieldGoalAsync(PlaySubmitDTO playSubmit)


### PR DESCRIPTION
Address:
- #61 
- #62 

Add functionality to PuntRepository:CreatePuntAsync(), GetSinglePuntAsync()
Add functionality to FieldGoalRepository:CreateFieldGoalAsync(), GetSingleFieldGoalAsync()

Add functionality to PlayService:CreatePlayAsyn() to validate and create Punt and FieldGoal from playSubmit

Involved reorganization of Kickoff validation process, some overlap with Punt & FieldGoal checks
Set FieldPositionEnd to (+/-)50 on made FieldGoal