### PR TITLE
Lateral & Fumble Create + VerifyPossessionChainAsync()

### DIFF
--- a/the-backfield/DTOs/PlayEntities/FumbleSubmitDTO.cs
+++ b/the-backfield/DTOs/PlayEntities/FumbleSubmitDTO.cs
@@ -7,7 +7,7 @@ public class FumbleSubmitDTO
     public int? Id { get; set; } = null;
     public int? PlayId { get; set; } = null;
     [Required]
-    public int? FumbleCommittedById { get; set; }
+    public int FumbleCommittedById { get; set; }
     public int? FumbledAt { get; set; } = null;
     public int? FumbleForcedById { get; set; } = null;
     public int? FumbleRecoveredById { get; set; } = null;

--- a/the-backfield/DTOs/PlayEntities/FumbleSubmitDTO.cs
+++ b/the-backfield/DTOs/PlayEntities/FumbleSubmitDTO.cs
@@ -7,7 +7,7 @@ public class FumbleSubmitDTO
     public int? Id { get; set; } = null;
     public int? PlayId { get; set; } = null;
     [Required]
-    public int FumbleCommittedById { get; set; }
+    public int? FumbleCommittedById { get; set; }
     public int? FumbledAt { get; set; } = null;
     public int? FumbleForcedById { get; set; } = null;
     public int? FumbleRecoveredById { get; set; } = null;

--- a/the-backfield/DTOs/PlayEntities/LateralSubmitDTO.cs
+++ b/the-backfield/DTOs/PlayEntities/LateralSubmitDTO.cs
@@ -8,6 +8,7 @@ public class LateralSubmitDTO
     public int? Id { get; set; } = null;
     public int? PlayId { get; set; } = null;
     [Required]
+    public int PrevCarrierId { get; set; }
     public int NewCarrierId { get; set; }
     public int? PossessionAt { get; set; } = null;
     public int? CarriedTo { get; set; } = null;

--- a/the-backfield/Data/TheBackfieldDbContext.cs
+++ b/the-backfield/Data/TheBackfieldDbContext.cs
@@ -155,6 +155,10 @@ public class TheBackfieldDbContext : DbContext
             .HasOne(l => l.NewCarrier)
             .WithMany()
             .OnDelete(DeleteBehavior.SetNull);
+        modelBuilder.Entity<Lateral>()
+            .HasOne(l => l.PrevCarrier)
+            .WithMany()
+            .OnDelete(DeleteBehavior.SetNull);
 
         modelBuilder.Entity<PlayPenalty>()
             .HasOne(pp => pp.Player)

--- a/the-backfield/Migrations/20241212060923_LateralFumbleUpdate.Designer.cs
+++ b/the-backfield/Migrations/20241212060923_LateralFumbleUpdate.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TheBackfield.Data;
@@ -11,9 +12,10 @@ using TheBackfield.Data;
 namespace the_backfield.Migrations
 {
     [DbContext(typeof(TheBackfieldDbContext))]
-    partial class TheBackfieldDbContextModelSnapshot : ModelSnapshot
+    [Migration("20241212060923_LateralFumbleUpdate")]
+    partial class LateralFumbleUpdate
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/the-backfield/Migrations/20241212060923_LateralFumbleUpdate.cs
+++ b/the-backfield/Migrations/20241212060923_LateralFumbleUpdate.cs
@@ -1,0 +1,83 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace the_backfield.Migrations
+{
+    public partial class LateralFumbleUpdate : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "PrevCarrierId",
+                table: "Laterals",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "RecoveredAt",
+                table: "Fumbles",
+                type: "integer",
+                nullable: true,
+                oldClrType: typeof(int),
+                oldType: "integer");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "FumbledAt",
+                table: "Fumbles",
+                type: "integer",
+                nullable: true,
+                oldClrType: typeof(int),
+                oldType: "integer");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Laterals_PrevCarrierId",
+                table: "Laterals",
+                column: "PrevCarrierId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Laterals_Players_PrevCarrierId",
+                table: "Laterals",
+                column: "PrevCarrierId",
+                principalTable: "Players",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.SetNull);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Laterals_Players_PrevCarrierId",
+                table: "Laterals");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Laterals_PrevCarrierId",
+                table: "Laterals");
+
+            migrationBuilder.DropColumn(
+                name: "PrevCarrierId",
+                table: "Laterals");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "RecoveredAt",
+                table: "Fumbles",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0,
+                oldClrType: typeof(int),
+                oldType: "integer",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "FumbledAt",
+                table: "Fumbles",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0,
+                oldClrType: typeof(int),
+                oldType: "integer",
+                oldNullable: true);
+        }
+    }
+}

--- a/the-backfield/Models/PlayEntities/Fumble.cs
+++ b/the-backfield/Models/PlayEntities/Fumble.cs
@@ -10,11 +10,11 @@ namespace TheBackfield.Models.PlayEntities
         public Play Play { get; set; }
         public int? FumbleCommittedById { get; set; } = null;
         public Player FumbleCommittedBy { get; set; }
-        public int FumbledAt { get; set; }
+        public int? FumbledAt { get; set; }
         public int? FumbleForcedById { get; set; } = null;
         public Player? FumbleForcedBy { get; set; }
         public int? FumbleRecoveredById { get; set; } = null;
         public Player? FumbleRecoveredBy { get; set; }
-        public int RecoveredAt { get; set; }
+        public int? RecoveredAt { get; set; }
     }
 }

--- a/the-backfield/Models/PlayEntities/Lateral.cs
+++ b/the-backfield/Models/PlayEntities/Lateral.cs
@@ -8,6 +8,8 @@ namespace TheBackfield.Models.PlayEntities
         [Required]
         public int PlayId { get; set; }
         public Play Play { get; set; }
+        public int? PrevCarrierId { get; set; } = null;
+        public Player PrevCarrier { get; set; }
         public int? NewCarrierId { get; set; } = null;
         public Player NewCarrier { get; set; }
         public int? PossessionAt { get; set; }

--- a/the-backfield/Repositories/PlayEntities/LateralRepository.cs
+++ b/the-backfield/Repositories/PlayEntities/LateralRepository.cs
@@ -27,8 +27,13 @@ public class LateralRepository : ILateralRepository
             return null;
         }
 
-        Player? carrier = await _dbContext.Players.AsNoTracking().SingleOrDefaultAsync(p => p.Id == lateralSubmit.NewCarrierId);
-        if (carrier == null)
+        Player? prevCarrier = await _dbContext.Players.AsNoTracking().SingleOrDefaultAsync(p => p.Id == lateralSubmit.PrevCarrierId);
+        if (prevCarrier == null)
+        {
+            return null;
+        }
+        Player? newCarrier = await _dbContext.Players.AsNoTracking().SingleOrDefaultAsync(p => p.Id == lateralSubmit.NewCarrierId);
+        if (newCarrier == null)
         {
             return null;
         }
@@ -36,6 +41,7 @@ public class LateralRepository : ILateralRepository
         Lateral newLateral = new()
         {
             PlayId = play.Id,
+            PrevCarrierId = lateralSubmit.PrevCarrierId,
             NewCarrierId = lateralSubmit.NewCarrierId,
             PossessionAt = lateralSubmit.PossessionAt,
             CarriedTo = lateralSubmit.CarriedTo


### PR DESCRIPTION
Address:
- #65 
- #68 

Add functionality to LateralRepository:CreateLateralAsync(), ReadSingleLateralAsync()
Add functionality to LateralRepository:CreateFumbleAsync(), ReadSingleFumbleAsync()

Add functionality to PlayService:CreatePlayAsync() to validate and create Lateral(s)/Fumble(s) from PlaySubmitDTO with nested LateralSubmitDTO(s) and FumbleSubmitDTO(s)

Add PrevCarrier to Lateral and LateralSubmtiDTO (required)

Converted FumbledAt & RecoveredAt in Fumble to nullable ints

Add PlayService:VerifyPossessionChainAsync() as extension of fumble, lateral data validation, establishes which team has possession and whether flow of possession between players is complete.

**Pull requires dotnet ef database update**