### PR TITLE
ParseFieldPosition bug, simplified GameStreamDTO constructor

### DIFF
--- a/the-backfield/DTOs/GameStream/GameStreamDTO.cs
+++ b/the-backfield/DTOs/GameStream/GameStreamDTO.cs
@@ -1,98 +1,18 @@
 ﻿using TheBackfield.Models;
-using TheBackfield.Utilities;
 
 namespace TheBackfield.DTOs.GameStream
 {
     public class GameStreamDTO
     {
         private readonly Game _game;
-        private readonly Play? _currentPlay;
-        private readonly int? _nextTeamId;
-        private readonly int? _lastFieldPositionEnd = null;
-        private readonly int _down;
-        private readonly int? _toGain;
-        public GameStreamDTO(Game game)
+        private readonly PlaySubmitDTO _nextPlay;
+        public GameStreamDTO(Game game, PlaySubmitDTO nextPlay)
         {
             _game = game;
-            _currentPlay = game.Plays.SingleOrDefault(p => !_game.Plays.Any(gp => gp.PrevPlayId == p.Id));
-            var (homeTeamScore, awayTeamScore) = StatClient.ParseScore(game);
-
-            if (_currentPlay != null)
-            {
-                var (down, toGain, fieldPositionEnd, nextTeamId) = StatClient.ParseFieldPosition(_currentPlay, game.HomeTeamId, game.AwayTeamId);
-                _down = down;
-                _toGain = toGain;
-                _lastFieldPositionEnd = fieldPositionEnd;
-                _nextTeamId = nextTeamId;
-            }
-            else
-            {
-                _down = 0;
-                _toGain = null;
-                _lastFieldPositionEnd = null;
-                _nextTeamId = null;
-            }
+            _nextPlay = nextPlay;
         }
         public Team? HomeTeam { get { return _game.HomeTeam; } }
         public Team? AwayTeam { get { return _game.AwayTeam; } }
-        public PlaySubmitDTO NextPlay
-        {
-            get
-            {
-                int? clockStart = null;
-                int? gamePeriod = null;
-                int playCheckId = _currentPlay?.Id ?? 0;
-                do
-                {
-                    Play? checkPlay = _game.Plays.SingleOrDefault(p => p.Id == playCheckId);
-                    if (checkPlay == null)
-                    {
-                        clockStart = _game.PeriodLength;
-                        gamePeriod = 1;
-                    }
-                    else
-                    {
-                        if (gamePeriod == null && checkPlay.GamePeriod != null)
-                        {
-                            gamePeriod = checkPlay.GamePeriod;
-                        }
-                        if (checkPlay.ClockEnd != null)
-                        {
-                            clockStart = checkPlay.ClockEnd;
-                        }
-                        else if (checkPlay.ClockStart != null)
-                        {
-                            clockStart = checkPlay.ClockStart;
-                        }
-                        else if (gamePeriod != null && (checkPlay.GamePeriod ?? gamePeriod) != gamePeriod)
-                        {
-                            clockStart = _game.PeriodLength;
-                        }
-                        else
-                        {
-                            playCheckId = checkPlay.PrevPlayId ?? 0;
-                        }
-                    }
-                } while (clockStart == null || gamePeriod == null);
-
-                if (clockStart == 0)
-                {
-                    gamePeriod += 1;
-                    clockStart = _game.PeriodLength;
-                }
-
-                return new PlaySubmitDTO
-                {
-                    PrevPlayId = _currentPlay?.Id ?? -1,
-                    GameId = _game.Id,
-                    TeamId = _nextTeamId ?? 0,
-                    FieldPositionStart = _lastFieldPositionEnd,
-                    Down = _down,
-                    ToGain = _toGain,
-                    ClockStart = clockStart,
-                    GamePeriod = gamePeriod
-                };
-            }
-        }
+        public PlaySubmitDTO NextPlay { get { return _nextPlay; } }
     }
 }

--- a/the-backfield/Services/PlayService.cs
+++ b/the-backfield/Services/PlayService.cs
@@ -1138,12 +1138,12 @@ namespace TheBackfield.Services
                     if (play.PassDefenders.Count() > 0)
                     {
                         segment.SegmentText += " Broken up by ";
-                        for (int i = 0; i < play.Tacklers.Count(); i++)
+                        for (int i = 0; i < play.PassDefenders.Count(); i++)
                         {
-                            Player? tackler = play.Tacklers[i].Tackler;
-                            if (tackler != null)
+                            Player? defender = play.PassDefenders[i].Defender;
+                            if (defender != null)
                             {
-                                segment.SegmentText += $"{tackler.FirstName?.Substring(0, 1).ToUpper()}. {tackler.LastName}";
+                                segment.SegmentText += $"{defender.FirstName?.Substring(0, 1).ToUpper()}. {defender.LastName}";
                             }
                             else
                             {

--- a/the-backfield/Utilities/StatClient.cs
+++ b/the-backfield/Utilities/StatClient.cs
@@ -111,10 +111,12 @@ namespace TheBackfield.Utilities
 
                     gainsPossession.Add(play.Pass?.Passer);
                     gainsPossession.Add(play.Pass?.Completion ?? false ? play.Pass?.Receiver ?? null : null);
+                    cedesPossession.Add(play.Pass?.Completion ?? false ? play.Pass?.Passer ?? null : null);
                     gainsPossession.Add(play.Rush?.Rusher);
                     gainsPossession.Add(play.Punt?.Returner);
                     gainsPossession.Add(play.Kickoff?.Returner);
                     gainsPossession.Add(play.Interception?.InterceptedBy);
+                    cedesPossession.Add(play.Interception != null ? play.Pass?.Passer ?? null : null);
                     gainsPossession.Add(play.KickBlock?.RecoveredBy);
                     foreach (Fumble fumble in play.Fumbles)
                     {
@@ -136,6 +138,10 @@ namespace TheBackfield.Utilities
                             gainsPossession.Remove(carrier);
                         }
                     }
+                    if (gainsPossession.Count() == 1)
+                    {
+                        teamId = gainsPossession[0]?.TeamId ?? 0;
+                    }
 
                     if (gainsPossession.Count == 0)
                     {
@@ -153,7 +159,7 @@ namespace TheBackfield.Utilities
                         }
                     }
                 }
-                if (teamId != play.TeamId)
+                if (teamId != play.TeamId && teamId != 0)
                 {
                     down = 1;
                     toGain = Math.Abs(fieldPosition + (teamSigns[teamId] * 10) ?? 0) > 50 ? teamSigns[teamId] * 50 : fieldPosition + (teamSigns[teamId] * 10);


### PR DESCRIPTION
Address bug wherein /games/{gameId}/game-stream call returned improper predictive PlaySubmitDTO data following play with interception.

Data into StatClient.ParseFieldPosition from GameStreamDTO constructor did not have sufficient data included to execute possession analysis

Moved most constructor logic from GameStreamDTO into GameService.GetGameStreamAsync(), called GetSinglePlayAsync() to pass into ParseFieldPosition (this call includes all player data).

StatClient.ParseFieldPosition did not include passer in cedesPossession list on completions or interceptions. Added checks to accomplish this.

StatClient.ParseFieldPosition did not check if hasPossession list had only one remaining player. Added code for this so as to set teamId to id of that player, which allows for proper analysis for possession.

Tested in Swagger and UI to check that PlaySubmitDTO now has correct nextPlay info.