### PR TITLE
Fixed Reconciliation 400 on pre-snap penalties

### DIFF
--- a/the-backfield/Services/PlayService.cs
+++ b/the-backfield/Services/PlayService.cs
@@ -1316,6 +1316,15 @@ namespace TheBackfield.Services
                 return (0, true);
             }
 
+            // If no players have received or relinquished possession and there is an enforced NoPlay penalty, then
+            // penalty is pre-snap and lack of possession chain is valid
+            if (hasPossession.Count == 0
+                && cedesPossession.Count == 0
+                && playSubmit.Penalties.Any((pp) => pp.Enforced == true && pp.NoPlay == true))
+            {
+                return (playSubmit.TeamId, false);
+            }
+
             if (hasPossession.Count == 0)
             {
                 if (playSubmit.FieldGoal && playSubmit.KickGood)


### PR DESCRIPTION
Address #96 

Add exception in PlayService.ValidatePossessionChainAsync() to accept chain of possession if ball is neither received nor relinquished by any player, and the play contains an enforced penalty where NoPlay == true

Will still mark as an invalid chain any playSubmitDTO where ball carrier data does exist (i.e. No Play penalties during play, dirty data)