### PR TITLE
Fixed bug where first down was not achieved with equal to line to gain

### DIFF
--- a/the-backfield/Utilities/StatClient.cs
+++ b/the-backfield/Utilities/StatClient.cs
@@ -79,7 +79,7 @@ namespace TheBackfield.Utilities
 
             if (enforcedPenalties.Any(ep => ep.NoPlay == true) && !enforcedPenalties.Any(ep => ep.LossOfDown == true))
             {
-                if (play.Kickoff == null && (enforcedPenalties.Any(ep => ep.AutoFirstDown == true) || (fieldPosition - toGain) * teamSigns[teamId] > 0))
+                if (play.Kickoff == null && (enforcedPenalties.Any(ep => ep.AutoFirstDown == true) || (fieldPosition - toGain) * teamSigns[teamId] >= 0))
                 {
                     down = 1;
                     toGain = Math.Abs((fieldPosition + (teamSigns[teamId] * 10)) ?? 0) > 50 ? teamSigns[teamId] * 50 : fieldPosition + (teamSigns[teamId] * 10);


### PR DESCRIPTION
Address #98 

StatClient.parseFieldPosition(), change first down requirement from fieldPosition greater than toGain to fieldPosition greater than or equal to toGain (greater than being past line to gain in direction of team travel)