### PR TITLE
GetPossessionChain, PossessionChangeDTO, PlayerStatsDTO

### DIFF
--- a/the-backfield/DTOs/GameStream/PossessionChangeDTO.cs
+++ b/the-backfield/DTOs/GameStream/PossessionChangeDTO.cs
@@ -1,0 +1,12 @@
+﻿namespace TheBackfield.DTOs.GameStream
+{
+    public class PossessionChangeDTO
+    {
+        public int FromPlayerId { get; set; }
+        public int ToPlayerId { get; set; }
+        public int? BallReceivedAt { get; set; }
+        public int? BallCarriedTo { get; set; }
+        public Type? EntityType { get; set; }
+        public int EntityId { get; set; }
+    }
+}

--- a/the-backfield/DTOs/PlayerStatsDTO.cs
+++ b/the-backfield/DTOs/PlayerStatsDTO.cs
@@ -1,0 +1,59 @@
+﻿using TheBackfield.Models;
+
+namespace TheBackfield.DTOs
+{
+    public class PlayerStatsDTO
+    {
+        public int PlayerId { get; set; }
+        public Player Player { get; set; } = new();
+        public int PassAttempts { get; set; }
+        public int PassCompletions { get; set; }
+        public int PassYards { get; set; }
+        public int PassTouchdowns { get; set; }
+        public int InterceptionsThrown { get; set; }
+        public int Receptions { get; set; }
+        public int ReceivingTargets { get; set; }
+        public int ReceivingYards { get; set; }
+        public int ReceivingTouchdowns { get; set; }
+        public int RushAttempts { get; set; }
+        public int RushYards { get; set; }
+        public int RushTouchdowns { get; set; }
+        public int FumblesCommitted { get; set; }
+        public int Tackles { get; set; }
+        public int SoloTackles { get; set; }
+        public int TacklesForLoss { get; set; }
+        public int Sacks { get; set; }
+        public int InterceptionsReceived { get; set; }
+        public int InterceptionReturnYards { get; set; }
+        public int InterceptionReturnTouchdowns { get; set; }
+        public int FumblesForced { get; set; }
+        public int FumblesRecovered { get; set; }
+        public int FumbleReturnYards { get; set; }
+        public int FumbleReturnTouchdowns { get; set; }
+        public int FieldGoalAttempts { get; set; }
+        public int FieldGoalsMade { get; set; }
+        public int ExtraPointAttempts { get; set; }
+        public int ExtraPointsMade { get; set; }
+        public int Punts { get; set; }
+        public int PuntYards { get; set; }
+        public decimal AveragePuntYards
+        {
+            get
+            {
+                if (Punts == 0)
+                {
+                    return 0;
+                }
+                return PuntYards / Punts;
+            }
+        }
+        public int Kickoffs { get; set; }
+        public int KickoffsForTouchbacks { get; set; }
+        public int KickoffReturns { get; set; }
+        public int KickoffReturnYards { get; set; }
+        public int KickoffReturnTouchdowns { get; set; }
+        public int PuntReturns { get; set; }
+        public int PuntReturnYards { get; set; }
+        public int PuntReturnTouchdowns { get; set; }
+    }
+}

--- a/the-backfield/Endpoints/PlayEndpoints.cs
+++ b/the-backfield/Endpoints/PlayEndpoints.cs
@@ -49,5 +49,16 @@ public static class PlayEndpoints
         })
             .WithOpenApi()
             .Produces(StatusCodes.Status204NoContent);
+
+        // For PlaySegment testing
+        // v---------------------v
+        //group.MapGet("/play-segments/{playId}", async (IPlayService playService, int playId) =>
+        //{
+        //    List<PlaySegmentDTO> response = await playService.GetPlaySegmentsAsync(playId);
+
+        //    return Results.Ok(response);
+        //})
+        //    .WithOpenApi()
+        //    .Produces<Play>(StatusCodes.Status200OK);
     }
 }

--- a/the-backfield/Services/PlayService.cs
+++ b/the-backfield/Services/PlayService.cs
@@ -842,6 +842,8 @@ namespace TheBackfield.Services
                 return [];
             }
 
+            List<List<PossessionChangeDTO>> possessionChains = StatClient.GetPossessionChain(play);
+
             int homeId = play.Game.HomeTeamId;
             int awayId = play.Game.AwayTeamId;
 


### PR DESCRIPTION
Created PlayerStatsDTO for future use in compiling and transferring stats to front-end, will be used in game-stream

Adapted StatClient.GetPossessionChain() from front-end logic. Possession chains are formed, next step is to add field position data in order to use for playSegments and PlayerStats.

Created PossessionChangeDTO for GetPossessionChain() method