### PR TITLE
Field Position data attached to possession chains

### DIFF
--- a/the-backfield/DTOs/GameStream/PossessionChangeDTO.cs
+++ b/the-backfield/DTOs/GameStream/PossessionChangeDTO.cs
@@ -4,8 +4,8 @@
     {
         public int FromPlayerId { get; set; }
         public int ToPlayerId { get; set; }
-        public int? BallReceivedAt { get; set; }
-        public int? BallCarriedTo { get; set; }
+        public int? FromPlayerAt { get; set; }
+        public int? ToPlayerAt { get; set; }
         public Type? EntityType { get; set; }
         public int EntityId { get; set; }
     }

--- a/the-backfield/Endpoints/PlayEndpoints.cs
+++ b/the-backfield/Endpoints/PlayEndpoints.cs
@@ -52,13 +52,13 @@ public static class PlayEndpoints
 
         // For PlaySegment testing
         // v---------------------v
-        //group.MapGet("/play-segments/{playId}", async (IPlayService playService, int playId) =>
-        //{
-        //    List<PlaySegmentDTO> response = await playService.GetPlaySegmentsAsync(playId);
+        group.MapGet("/play-segments/{playId}", async (IPlayService playService, int playId) =>
+        {
+            List<PlaySegmentDTO> response = await playService.GetPlaySegmentsAsync(playId);
 
-        //    return Results.Ok(response);
-        //})
-        //    .WithOpenApi()
-        //    .Produces<Play>(StatusCodes.Status200OK);
+            return Results.Ok(response);
+        })
+            .WithOpenApi()
+            .Produces<Play>(StatusCodes.Status200OK);
     }
 }

--- a/the-backfield/Services/PlayService.cs
+++ b/the-backfield/Services/PlayService.cs
@@ -1226,10 +1226,10 @@ namespace TheBackfield.Services
                     if (segment.FieldStart != null)
                     {
                         int yardage = (segment.FieldEnd - segment.FieldStart ?? 0) * teamSigns[segment.TeamId];
-                        segment.SegmentText += $" to {StatClient.FieldPositionText(segment.FieldEnd, teams[homeId], teams[awayId])} for {yardage} yard{(Math.Abs(yardage) == 1 ? "" : "s")}";
+                        segment.SegmentText += $" for {yardage} yard{(Math.Abs(yardage) == 1 ? "" : "s")}";
                     }
                 }
-                segment.SegmentText = ".";
+                segment.SegmentText += ".";
                 segments.Add(segment);
             }
 


### PR DESCRIPTION
Address #104 

Field position data added to each change in a possession change, shows where possession was relinquished (FromPlayerAt), and where it was attained (ToPlayerAt)

All possession chains have a start cap (where FromPlayerId = 0) and an end cap (where ToPlayerId = 0)
On complete passes, possession switches at point of throw, count receiving yards by difference between changes
PossessionChains only calculable for plays with a pass, rush, or kick