### PR TITLE
Play Segment Text

### DIFF
--- a/the-backfield/DTOs/GameStream/PlaySegmentDTO.cs
+++ b/the-backfield/DTOs/GameStream/PlaySegmentDTO.cs
@@ -7,5 +7,7 @@
         public int? FieldEnd { get; set; }
         public int TeamId { get; set; }
         public string SegmentText { get; set; } = "";
+        public string LineType { get; set; } = "";
+        public string EndpointType { get; set; } = "";
     }
 }

--- a/the-backfield/Models/Player.cs
+++ b/the-backfield/Models/Player.cs
@@ -17,4 +17,57 @@ public class Player
     [Required]
     public int UserId { get; set; }
     public List<Position> Positions { get; set; } = [];
+
+    public string Name()
+    {
+        string playerText = "";
+
+        if (FirstName != "" && FirstName != null)
+        {
+            if (LastName != "" && LastName != null)
+            {
+                playerText += $"{FirstName[..1].ToUpper()}.";
+            }
+            else
+            {
+                playerText += FirstName;
+            }
+        }
+
+        if (LastName != "" && LastName != null)
+        {
+            if (playerText != "")
+            {
+                playerText += " ";
+            }
+            playerText += LastName;
+        }
+
+        return playerText;
+    }
+    public string NameAndNumber()
+    {
+        string playerText = "";
+
+        if (FirstName != "" && FirstName != null)
+        {
+            if (LastName != "" && LastName != null)
+            {
+                playerText += $"{FirstName[..1].ToUpper()}. ";
+            }
+            else
+            {
+                playerText += $"{FirstName} ";
+            }
+        }
+
+        if (LastName != "" && LastName != null)
+        {
+            playerText += $"{LastName} ";
+        }
+
+        playerText += $"#{JerseyNumber}";
+
+        return playerText;
+    }
 }

--- a/the-backfield/Services/GameService.cs
+++ b/the-backfield/Services/GameService.cs
@@ -171,7 +171,7 @@ public class GameService : IGameService
         // The drive always has at least one play in it (that play may be an empty play if at start of game or currentPlay is otherwise null)
         List<Play> drive = [currentPlay ?? new()];
 
-        bool driveFound = false;
+        bool driveFound = currentPlay?.TeamId != nextTeamId;
 
         // Collect all plays from current drive, including kickoff to start drive (does not count as a play)
         while (drive[0].Kickoff == null && drive[0].PrevPlayId > 0 && !driveFound)

--- a/the-backfield/Services/PlayService.cs
+++ b/the-backfield/Services/PlayService.cs
@@ -1376,7 +1376,15 @@ namespace TheBackfield.Services
                 }
             }
 
-            foreach (PlayPenalty penalty in play.Penalties)
+            // Account for safeties
+            if (play.Safety != null)
+            {
+                PlaySegmentDTO segment = segments[^1];
+                segment.SegmentText += $" Safety {teamsInv[segment.TeamId]}";
+            }
+
+            // Account for penalties
+            foreach (PlayPenalty penalty in play.Penalties.OrderBy((p) => p.Enforced))
             {
                 PlaySegmentDTO segment = new()
                 {


### PR DESCRIPTION
Address #106 

Refactor GetPlaySegments() to loop through the first chain output by GetPossessionChain() and use to parse aspects of a play consecutively. Allows for the variable inclusion of laterals and fumbles.

WARNING: GetPossessionChain() behavior will now greatly affect GetPlaySegments() output. Tests needed.

Tacklers, Touchdowns, Extra Points, Conversions, Safeties, and PlayPenalties are appended outside of loop.

GetPlaySegments() results in list of segmented text strings with associated ball movement and possession team information for use in GameStream display.

Add LineType and EndpointType properties to PlaySegmentDTO model to communicate information regarding how the ball was moved (pass, kick, run, penalty, etc.) and the result of that movement (completion, recovery, missed kick, etc.), respectively, to the user. This remains unimplemented, outside of the marking of "penalty" for both on penalties, but will be utilized to add extra styling cues to the front-end GameStreamDisplay.

Add Name() and NameAndNumber() methods to Player.cs to retrieve string with either

Set driveFound bool in GetGameStreamAsync() to true if the currentPlay has a different teamId than the next play. This fixed a bug where turnovers on consecutive plays resulted in the inclusion of plays from the next team's previous drive.

HOW TO TEST:
Use play-segments/[playId] endpoint and compare what is included in the play (either with debugger, in pgAdmin, or with separate get play call) to the text output in the play segment(s).
