### PR TITLE
PlaySegments added to Gamestream

### DIFF
--- a/the-backfield.Tests/GameServiceTests.cs
+++ b/the-backfield.Tests/GameServiceTests.cs
@@ -13,6 +13,7 @@ namespace TheBackfield.Tests
         private readonly Mock<IPlayRepository> _mockPlayRepository;
         private readonly Mock<IUserRepository> _mockUserRepository;
         private readonly Mock<ITeamRepository> _mockTeamRepository;
+        private readonly Mock<IPlayService> _mockPlayService;
         private static User TestUser { get; } = new User { Id = 14, Username = "testman", SessionKey = "Hfue82jL_14", Uid = "testmanjenkins" };
         private static Team TestTeam1 { get; } = new Team { Id = 2, LocationName = "Cybernet", Nickname = "Testmen", UserId = 14 };
         private static Team TestTeam2 { get; } = new Team { Id = 4, LocationName = "Matrix", Nickname = "Andersons", UserId = 14 };
@@ -35,7 +36,8 @@ namespace TheBackfield.Tests
             _mockPlayRepository = new Mock<IPlayRepository>();
             _mockUserRepository = new Mock<IUserRepository>();
             _mockTeamRepository = new Mock<ITeamRepository>();
-            _gameService = new GameService(_mockGameRepository.Object, _mockPlayRepository.Object, _mockTeamRepository.Object, _mockUserRepository.Object);
+            _mockPlayService = new Mock<IPlayService>();
+            _gameService = new GameService(_mockGameRepository.Object, _mockPlayRepository.Object, _mockTeamRepository.Object, _mockUserRepository.Object, _mockPlayService.Object);
         }
 
         [Fact]

--- a/the-backfield/DTOs/GameStream/GameStreamDTO.cs
+++ b/the-backfield/DTOs/GameStream/GameStreamDTO.cs
@@ -19,6 +19,7 @@ namespace TheBackfield.DTOs.GameStream
         public int? DrivePositionStart { get; set; }
         public int DriveYards { get; set; }
         public int DriveTime { get; set; }
+        public PlayAsSegmentsDTO? LastPlay { get; set; }
         public PlaySubmitDTO NextPlay { get { return _nextPlay; } }
     }
 }

--- a/the-backfield/DTOs/GameStream/PlayAsSegmentsDTO.cs
+++ b/the-backfield/DTOs/GameStream/PlayAsSegmentsDTO.cs
@@ -1,0 +1,32 @@
+﻿using TheBackfield.Models;
+
+namespace TheBackfield.DTOs.GameStream
+{
+    public class PlayAsSegmentsDTO
+    {
+        private readonly Play _play;
+        private List<PlaySegmentDTO> _playSegments;
+        public PlayAsSegmentsDTO(Play play, List<PlaySegmentDTO> playSegments)
+        {
+            _play = play;
+            _playSegments = playSegments ?? [];
+        }
+        public int Id { get { return _play.Id; } }
+        public int? PrevPlayId { get { return _play.PrevPlayId; } }
+        public int? GameId { get { return _play.GameId; } }
+        public int? TeamId { get { return _play.TeamId; } }
+        public int? FieldPositionStart { get { return _play.FieldPositionStart; } }
+        public int? FieldPositionEnd { get { return _play.FieldPositionEnd; } }
+        public int Down { get { return _play.Down; } }
+        public int? ToGain { get { return _play.ToGain; } }
+        public int? ClockStart { get { return _play.ClockStart; } }
+        public int? ClockEnd { get { return _play.ClockEnd; } }
+        public int? GamePeriod { get { return _play.GamePeriod; } }
+        public string Notes { get { return _play.Notes; } }
+        public List<PlaySegmentDTO> PlaySegments
+        {
+            get { return _playSegments; } 
+            set { _playSegments = value; }
+        }
+    }
+}

--- a/the-backfield/Endpoints/PlayEndpoints.cs
+++ b/the-backfield/Endpoints/PlayEndpoints.cs
@@ -52,13 +52,13 @@ public static class PlayEndpoints
 
         // For PlaySegment testing
         // v---------------------v
-        group.MapGet("/play-segments/{playId}", async (IPlayService playService, int playId) =>
-        {
-            List<PlaySegmentDTO> response = await playService.GetPlaySegmentsAsync(playId);
+        //group.MapGet("/play-segments/{playId}", async (IPlayService playService, int playId) =>
+        //{
+        //    List<PlaySegmentDTO> response = await playService.GetPlaySegmentsAsync(playId);
 
-            return Results.Ok(response);
-        })
-            .WithOpenApi()
-            .Produces<Play>(StatusCodes.Status200OK);
+        //    return Results.Ok(response);
+        //})
+        //    .WithOpenApi()
+        //    .Produces<Play>(StatusCodes.Status200OK);
     }
 }


### PR DESCRIPTION
Created PlayAsSegmentsDTO to carry basic play info and remaining play data as a list of PlaySegmentDTOs. Data is derived from passing a Play and List<PlaySegmentDTO> into constructor, though PlaySegments can be assigned later outside constructor.

Added LastPlay property to GameStreamDTO, is a PlayAsSegmentsDTO

Adjusted GameServiceTests to include mock PlayService (added to GameService constructor for use in calling GetPlaySegmentsAsync(), not implemented in any tests)

DrivePositionStart in gameStream now defaults to the nextFieldPositionStart if drive has not yet started, useful for front-end in visual implementation of GameStreamDisplay