### PR TITLE
Drive Count / Interception in Play Segment bugs

### DIFF
--- a/the-backfield/Services/PlayService.cs
+++ b/the-backfield/Services/PlayService.cs
@@ -1072,7 +1072,7 @@ namespace TheBackfield.Services
                     segments.Add(segment);
                 }
 
-                if (((chain[i].EntityType == typeof(Pass) && (i > 0 || !play.Pass.Completion))
+                if (((chain[i].EntityType == typeof(Pass) && (i > 0 || (!play.Pass.Completion && play.Interception == null)))
                         || chain[i].EntityType == typeof(Interception))
                     && i < chain.Count() - 1)
                 {


### PR DESCRIPTION
Altered drive calculation behavior in GetGameStreamAsync() to include plays negated by penalties in the drive stats except as a play in the drive count

Added extra logic gate to avoid double counting of interceptions in GetPlaySegmentsAsync()