### PR TITLE
SignalR Websocket Setup for Watch Page live GameStream Update

### DIFF
--- a/the-backfield.Tests/the-backfield.Tests.csproj
+++ b/the-backfield.Tests/the-backfield.Tests.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="9.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/the-backfield/Data/WatchGame.cs
+++ b/the-backfield/Data/WatchGame.cs
@@ -15,6 +15,7 @@ namespace TheBackfield.Data
         {
             int.TryParse(Context.GetHttpContext()?.Request.Query["gameId"], out int gameId);
             await Groups.AddToGroupAsync(Context.ConnectionId, $"watch-{gameId}");
+
             await Clients.Group($"watch-{gameId}").SayHello($"Greetings {Context.ConnectionId}, you're watching {gameId}!");
         }
         public async Task Report(int gameId)

--- a/the-backfield/Data/WatchGame.cs
+++ b/the-backfield/Data/WatchGame.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.AspNetCore.SignalR;
+using TheBackfield.DTOs.GameStream;
+using TheBackfield.Interfaces;
+
+namespace TheBackfield.Data
+{
+    public class WatchGame : Hub<IWatchClient>
+    {
+        private readonly IGameService _gameService;
+        public WatchGame(IGameService gameService)
+        {
+            _gameService = gameService;
+        }
+        public override async Task OnConnectedAsync()
+        {
+            int.TryParse(Context.GetHttpContext()?.Request.Query["gameId"], out int gameId);
+            await Groups.AddToGroupAsync(Context.ConnectionId, $"watch-{gameId}");
+            await Clients.Group($"watch-{gameId}").SayHello($"Greetings {Context.ConnectionId}, you're watching {gameId}!");
+        }
+        public async Task Report(int gameId)
+        {
+            GameStreamDTO? gameStream = await _gameService.GetGameStreamAsync(gameId);
+            if (gameStream != null)
+            {
+                await Clients.Group($"watch-{gameId}").UpdateGameStream(gameStream);
+            }
+        }
+    }
+}

--- a/the-backfield/Endpoints/GameEndpoints.cs
+++ b/the-backfield/Endpoints/GameEndpoints.cs
@@ -2,6 +2,7 @@ using TheBackfield.DTOs.GameStream;
 using TheBackfield.DTOs;
 using TheBackfield.Interfaces;
 using TheBackfield.Models;
+using TheBackfield.Data;
 
 namespace TheBackfield.Endpoints;
 
@@ -104,5 +105,7 @@ public static class GameEndpoints
         })
             .WithOpenApi()
             .Produces(StatusCodes.Status204NoContent);
+
+        group.MapHub<WatchGame>($"watch");
     }
 }

--- a/the-backfield/Interfaces/IWatchClient.cs
+++ b/the-backfield/Interfaces/IWatchClient.cs
@@ -1,0 +1,10 @@
+﻿using TheBackfield.DTOs.GameStream;
+
+namespace TheBackfield.Interfaces
+{
+    public interface IWatchClient
+    {
+        Task SayHello(string greeting);
+        Task UpdateGameStream(GameStreamDTO gameStream);
+    }
+}

--- a/the-backfield/Program.cs
+++ b/the-backfield/Program.cs
@@ -70,7 +70,7 @@ builder.Services.AddCors(options =>
     options.AddDefaultPolicy(policy =>
     {
         policy.WithOrigins("http://localhost:3000")
-            .AllowAnyOrigin()
+            .AllowCredentials()
             .AllowAnyMethod()
             .AllowAnyHeader();
     });

--- a/the-backfield/Program.cs
+++ b/the-backfield/Program.cs
@@ -63,6 +63,7 @@ builder.Services.AddScoped<IUserRepository, UserRepository>();
 
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
+builder.Services.AddSignalR();
 
 builder.Services.AddCors(options =>
 {

--- a/the-backfield/the-backfield.csproj
+++ b/the-backfield/the-backfield.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.4" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="9.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Installed and integrated SignalR, establishing WatchGame hub and IWatchClient

Added websocket update to active game subs on successful POST /plays

Adjusted CORS policy to AllowCredentials(), removed AllowAnyOrigin()