### PR TITLE
Fixed bug that prevented changes in possession on fumbles

### DIFF
--- a/the-backfield/Utilities/StatClient.cs
+++ b/the-backfield/Utilities/StatClient.cs
@@ -164,9 +164,12 @@ namespace TheBackfield.Utilities
 
                     foreach (Player? carrier in cedesPossession)
                     {
-                        if (gainsPossession.Contains(carrier))
+                        if (carrier != null && gainsPossession.Count((p) => p?.Id == carrier.Id) != 0)
                         {
-                            gainsPossession.Remove(carrier);
+                            var player = gainsPossession
+                                .Select((p, index) => new { p?.Id, Index = index })
+                                .SingleOrDefault((item) => item.Id == carrier.Id);
+                            gainsPossession.RemoveAt(player?.Index ?? -1);
                         }
                     }
                     if (gainsPossession.Count() == 1)


### PR DESCRIPTION
Address #112 

StatClient.ParseNextFieldPosition() was not removing all of the players in gainsPossession from cedesPossession (reason unclear, as it would remove some but fail on loop)

Rewrote logic in StatClient.ParseNextFieldPosition() for more explicit match and removal of of player in gainsPossession list