### PR TITLE
Added new properties to some play auxiliaries for stat calculation

### DIFF
--- a/the-backfield/Migrations/20250112090855_PlayAuxExtraStats.Designer.cs
+++ b/the-backfield/Migrations/20250112090855_PlayAuxExtraStats.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TheBackfield.Data;
@@ -11,9 +12,10 @@ using TheBackfield.Data;
 namespace the_backfield.Migrations
 {
     [DbContext(typeof(TheBackfieldDbContext))]
-    partial class TheBackfieldDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250112090855_PlayAuxExtraStats")]
+    partial class PlayAuxExtraStats
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/the-backfield/Migrations/20250112090855_PlayAuxExtraStats.cs
+++ b/the-backfield/Migrations/20250112090855_PlayAuxExtraStats.cs
@@ -1,0 +1,218 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace the_backfield.Migrations
+{
+    public partial class PlayAuxExtraStats : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Touchdowns_PlayId",
+                table: "Touchdowns");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Safeties_PlayId",
+                table: "Safeties");
+
+            migrationBuilder.AddColumn<int>(
+                name: "Yardage",
+                table: "Rushes",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "Distance",
+                table: "Punts",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "ReturnYardage",
+                table: "Punts",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "Sack",
+                table: "Passes",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "Spike",
+                table: "Passes",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<string>(
+                name: "YardageType",
+                table: "Laterals",
+                type: "text",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<int>(
+                name: "Distance",
+                table: "Kickoffs",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "ReturnYardage",
+                table: "Kickoffs",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "LooseBallYardage",
+                table: "KickBlocks",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "ReturnYardage",
+                table: "KickBlocks",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "ReturnYardage",
+                table: "Interceptions",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "LooseBallYardage",
+                table: "Fumbles",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "ReturnYardage",
+                table: "Fumbles",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<string>(
+                name: "YardageType",
+                table: "Fumbles",
+                type: "text",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<int>(
+                name: "Distance",
+                table: "FieldGoals",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Touchdowns_PlayId",
+                table: "Touchdowns",
+                column: "PlayId",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Safeties_PlayId",
+                table: "Safeties",
+                column: "PlayId",
+                unique: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Touchdowns_PlayId",
+                table: "Touchdowns");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Safeties_PlayId",
+                table: "Safeties");
+
+            migrationBuilder.DropColumn(
+                name: "Yardage",
+                table: "Rushes");
+
+            migrationBuilder.DropColumn(
+                name: "Distance",
+                table: "Punts");
+
+            migrationBuilder.DropColumn(
+                name: "ReturnYardage",
+                table: "Punts");
+
+            migrationBuilder.DropColumn(
+                name: "Sack",
+                table: "Passes");
+
+            migrationBuilder.DropColumn(
+                name: "Spike",
+                table: "Passes");
+
+            migrationBuilder.DropColumn(
+                name: "YardageType",
+                table: "Laterals");
+
+            migrationBuilder.DropColumn(
+                name: "Distance",
+                table: "Kickoffs");
+
+            migrationBuilder.DropColumn(
+                name: "ReturnYardage",
+                table: "Kickoffs");
+
+            migrationBuilder.DropColumn(
+                name: "LooseBallYardage",
+                table: "KickBlocks");
+
+            migrationBuilder.DropColumn(
+                name: "ReturnYardage",
+                table: "KickBlocks");
+
+            migrationBuilder.DropColumn(
+                name: "ReturnYardage",
+                table: "Interceptions");
+
+            migrationBuilder.DropColumn(
+                name: "LooseBallYardage",
+                table: "Fumbles");
+
+            migrationBuilder.DropColumn(
+                name: "ReturnYardage",
+                table: "Fumbles");
+
+            migrationBuilder.DropColumn(
+                name: "YardageType",
+                table: "Fumbles");
+
+            migrationBuilder.DropColumn(
+                name: "Distance",
+                table: "FieldGoals");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Touchdowns_PlayId",
+                table: "Touchdowns",
+                column: "PlayId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Safeties_PlayId",
+                table: "Safeties",
+                column: "PlayId");
+        }
+    }
+}

--- a/the-backfield/Models/PlayEntities/FieldGoal.cs
+++ b/the-backfield/Models/PlayEntities/FieldGoal.cs
@@ -12,5 +12,6 @@ namespace TheBackfield.Models.PlayEntities
         public Player? Kicker { get; set; }
         public bool Good { get; set; }
         public bool Fake { get; set; }
+        public int Distance { get; set; }
     }
 }

--- a/the-backfield/Models/PlayEntities/Fumble.cs
+++ b/the-backfield/Models/PlayEntities/Fumble.cs
@@ -16,5 +16,8 @@ namespace TheBackfield.Models.PlayEntities
         public int? FumbleRecoveredById { get; set; } = null;
         public Player? FumbleRecoveredBy { get; set; }
         public int? RecoveredAt { get; set; }
+        public int LooseBallYardage { get; set; }
+        public int ReturnYardage { get; set; }
+        public string YardageType { get; set; } = "";
     }
 }

--- a/the-backfield/Models/PlayEntities/Interception.cs
+++ b/the-backfield/Models/PlayEntities/Interception.cs
@@ -11,5 +11,6 @@ namespace TheBackfield.Models.PlayEntities
         public int? InterceptedById { get; set; } = null;
         public Player InterceptedBy { get; set; }
         public int? InterceptedAt { get; set; }
+        public int ReturnYardage { get; set; }
     }
 }

--- a/the-backfield/Models/PlayEntities/KickBlock.cs
+++ b/the-backfield/Models/PlayEntities/KickBlock.cs
@@ -13,6 +13,7 @@ namespace TheBackfield.Models.PlayEntities
         public int? RecoveredById { get; set; } = null;
         public Player? RecoveredBy { get; set; }
         public int? RecoveredAt { get; set; }
-
+        public int LooseBallYardage { get; set; }
+        public int ReturnYardage { get; set; }
     }
 }

--- a/the-backfield/Models/PlayEntities/Kickoff.cs
+++ b/the-backfield/Models/PlayEntities/Kickoff.cs
@@ -14,5 +14,7 @@ namespace TheBackfield.Models.PlayEntities
         public Player? Returner { get; set; }
         public int? FieldedAt { get; set; } = null;
         public bool Touchback { get; set; }
+        public int Distance { get; set; }
+        public int ReturnYardage { get; set; }
     }
 }

--- a/the-backfield/Models/PlayEntities/Lateral.cs
+++ b/the-backfield/Models/PlayEntities/Lateral.cs
@@ -14,5 +14,6 @@ namespace TheBackfield.Models.PlayEntities
         public Player NewCarrier { get; set; }
         public int? PossessionAt { get; set; }
         public int? CarriedTo { get; set; }
+        public string YardageType { get; set; } = "";
     }
 }

--- a/the-backfield/Models/PlayEntities/Pass.cs
+++ b/the-backfield/Models/PlayEntities/Pass.cs
@@ -13,5 +13,7 @@ namespace TheBackfield.Models.PlayEntities
         public int? ReceiverId { get; set; } = null;
         public Player? Receiver { get; set; }
         public bool Completion { get; set; } = false;
+        public bool Sack { get; set; } = false;
+        public bool Spike { get; set; } = false;
     }
 }

--- a/the-backfield/Models/PlayEntities/Punt.cs
+++ b/the-backfield/Models/PlayEntities/Punt.cs
@@ -16,5 +16,7 @@ namespace TheBackfield.Models.PlayEntities
         public bool FairCatch { get; set; }
         public bool Touchback { get; set; }
         public bool Fake { get; set; }
+        public int Distance { get; set; }
+        public int ReturnYardage { get; set; }
     }
 }

--- a/the-backfield/Models/PlayEntities/Rush.cs
+++ b/the-backfield/Models/PlayEntities/Rush.cs
@@ -10,5 +10,6 @@ namespace TheBackfield.Models.PlayEntities
         public Play Play { get; set; }
         public int? RusherId { get; set; } = null;
         public Player? Rusher { get; set; }
+        public int Yardage { get; set; }
     }
 }


### PR DESCRIPTION
Added yardage, yardage type, and other properties to several play auxiliaries to simplify stat calculation and avoid having to rebuild and parse possession chains for every play involved in a PlayerStats read.

New properties will be calculated on play create/update, but otherwise do not alter PlaySubmitDTO or any existing methods