### PR TITLE
Add Create[PlayAux]Async() overloads that accept entity

### DIFF
--- a/the-backfield/Interfaces/PlayEntities/IConversionRepository.cs
+++ b/the-backfield/Interfaces/PlayEntities/IConversionRepository.cs
@@ -7,6 +7,7 @@ public interface IConversionRepository
 {
     Task<Conversion?> GetSingleConversionAsync(int conversionId);
     Task<Conversion?> CreateConversionAsync(PlaySubmitDTO playSubmit);
+    Task<Conversion?> CreateConversionAsync(Conversion newConversion);
     Task<Conversion?> UpdateConversionAsync(PlaySubmitDTO playSubmit);
     Task<bool> DeleteConversionAsync(int conversionId);
 }

--- a/the-backfield/Interfaces/PlayEntities/IExtraPointRepository.cs
+++ b/the-backfield/Interfaces/PlayEntities/IExtraPointRepository.cs
@@ -7,6 +7,7 @@ public interface IExtraPointRepository
 {
     Task<ExtraPoint?> GetSingleExtraPointAsync(int extraPointId);
     Task<ExtraPoint?> CreateExtraPointAsync(PlaySubmitDTO playSubmit);
+    Task<ExtraPoint?> CreateExtraPointAsync(ExtraPoint newExtraPoint);
     Task<ExtraPoint?> UpdateExtraPointAsync(PlaySubmitDTO playSubmit);
     Task<bool> DeleteExtraPointAsync(int extraPointId);
 }

--- a/the-backfield/Interfaces/PlayEntities/IFieldGoalRepository.cs
+++ b/the-backfield/Interfaces/PlayEntities/IFieldGoalRepository.cs
@@ -7,6 +7,7 @@ public interface IFieldGoalRepository
 {
     Task<FieldGoal?> GetSingleFieldGoalAsync(int fieldGoalId);
     Task<FieldGoal?> CreateFieldGoalAsync(PlaySubmitDTO playSubmit);
+    Task<FieldGoal?> CreateFieldGoalAsync(FieldGoal newFieldGoal);
     Task<FieldGoal?> UpdateFieldGoalAsync(PlaySubmitDTO playSubmit);
     Task<bool> DeleteFieldGoalAsync(int fieldGoalId);
 }

--- a/the-backfield/Interfaces/PlayEntities/IFumbleRepository.cs
+++ b/the-backfield/Interfaces/PlayEntities/IFumbleRepository.cs
@@ -7,6 +7,7 @@ public interface IFumbleRepository
 {
     Task<Fumble?> GetSingleFumbleAsync(int fumbleId);
     Task<Fumble?> CreateFumbleAsync(FumbleSubmitDTO fumbleSubmit);
+    Task<Fumble?> CreateFumbleAsync(Fumble newFumble);
     Task<Fumble?> UpdateFumbleAsync(FumbleSubmitDTO fumbleSubmit);
     Task<bool> DeleteFumbleAsync(int fumbleId);
 }

--- a/the-backfield/Interfaces/PlayEntities/IInterceptionRepository.cs
+++ b/the-backfield/Interfaces/PlayEntities/IInterceptionRepository.cs
@@ -7,6 +7,7 @@ public interface IInterceptionRepository
 {
     Task<Interception?> GetSingleInterceptionAsync(int interceptionId);
     Task<Interception?> CreateInterceptionAsync(PlaySubmitDTO playSubmit);
+    Task<Interception?> CreateInterceptionAsync(Interception newInterception);
     Task<Interception?> UpdateInterceptionAsync(PlaySubmitDTO playSubmit);
     Task<bool> DeleteInterceptionAsync(int interceptionId);
 }

--- a/the-backfield/Interfaces/PlayEntities/IKickBlockRepository.cs
+++ b/the-backfield/Interfaces/PlayEntities/IKickBlockRepository.cs
@@ -7,6 +7,7 @@ public interface IKickBlockRepository
 {
     Task<KickBlock?> GetSingleKickBlockAsync(int kickBlockId);
     Task<KickBlock?> CreateKickBlockAsync(PlaySubmitDTO playSubmit);
+    Task<KickBlock?> CreateKickBlockAsync(KickBlock newKickBlock);
     Task<KickBlock?> UpdateKickBlockAsync(PlaySubmitDTO playSubmit);
     Task<bool> DeleteKickBlockAsync(int kickBlockId);
 }

--- a/the-backfield/Interfaces/PlayEntities/IKickoffRepository.cs
+++ b/the-backfield/Interfaces/PlayEntities/IKickoffRepository.cs
@@ -7,6 +7,7 @@ public interface IKickoffRepository
 {
     Task<Kickoff?> GetSingleKickoffAsync(int kickoffId);
     Task<Kickoff?> CreateKickoffAsync(PlaySubmitDTO playSubmit);
+    Task<Kickoff?> CreateKickoffAsync(Kickoff newKickoff);
     Task<Kickoff?> UpdateKickoffAsync(PlaySubmitDTO playSubmit);
     Task<bool> DeleteKickoffAsync(int kickoffId);
 }

--- a/the-backfield/Interfaces/PlayEntities/ILateralRepository.cs
+++ b/the-backfield/Interfaces/PlayEntities/ILateralRepository.cs
@@ -7,6 +7,7 @@ public interface ILateralRepository
 {
     Task<Lateral?> GetSingleLateralAsync(int lateralId);
     Task<Lateral?> CreateLateralAsync(LateralSubmitDTO lateralSubmit);
+    Task<Lateral?> CreateLateralAsync(Lateral newLateral);
     Task<Lateral?> UpdateLateralAsync(LateralSubmitDTO lateralSubmit);
     Task<bool> DeleteLateralAsync(int lateralId);
 }

--- a/the-backfield/Interfaces/PlayEntities/IPassDefenseRepository.cs
+++ b/the-backfield/Interfaces/PlayEntities/IPassDefenseRepository.cs
@@ -5,5 +5,6 @@ namespace TheBackfield.Interfaces.PlayEntities;
 public interface IPassDefenseRepository
 {
     Task<PassDefense?> CreatePassDefenseAsync(int playId, int defenderId);
+    Task<PassDefense?> CreatePassDefenseAsync(PassDefense newPassDefense);
     Task<bool> DeletePassDefenseAsync(int passDefenseId);
 }

--- a/the-backfield/Interfaces/PlayEntities/IPassRepository.cs
+++ b/the-backfield/Interfaces/PlayEntities/IPassRepository.cs
@@ -7,6 +7,7 @@ public interface IPassRepository
 {
     Task<Pass?> GetSinglePassAsync(int passId);
     Task<Pass?> CreatePassAsync(PlaySubmitDTO playSubmit);
+    Task<Pass?> CreatePassAsync(Pass newPass);
     Task<Pass?> UpdatePassAsync(PlaySubmitDTO playSubmit);
     Task<bool> DeletePassAsync(int passId);
 }

--- a/the-backfield/Interfaces/PlayEntities/IPlayPenaltyRepository.cs
+++ b/the-backfield/Interfaces/PlayEntities/IPlayPenaltyRepository.cs
@@ -7,6 +7,7 @@ public interface IPlayPenaltyRepository
 {
     Task<PlayPenalty?> GetSinglePlayPenaltyAsync(int playPenaltyId);
     Task<PlayPenalty?> CreatePlayPenaltyAsync(PlayPenaltySubmitDTO playPenaltySubmit);
+    Task<PlayPenalty?> CreatePlayPenaltyAsync(PlayPenalty newPlayPenalty);
     Task<PlayPenalty?> UpdatePlayPenaltyAsync(PlayPenaltySubmitDTO playPenaltySubmit);
     Task<bool> DeletePlayPenaltyAsync(int playPenaltyId);
 }

--- a/the-backfield/Interfaces/PlayEntities/IPuntRepository.cs
+++ b/the-backfield/Interfaces/PlayEntities/IPuntRepository.cs
@@ -7,6 +7,7 @@ public interface IPuntRepository
 {
     Task<Punt?> GetSinglePuntAsync(int puntId);
     Task<Punt?> CreatePuntAsync(PlaySubmitDTO playSubmit);
+    Task<Punt?> CreatePuntAsync(Punt newPunt);
     Task<Punt?> UpdatePuntAsync(PlaySubmitDTO playSubmit);
     Task<bool> DeletePuntAsync(int puntId);
 }

--- a/the-backfield/Interfaces/PlayEntities/IRushRepository.cs
+++ b/the-backfield/Interfaces/PlayEntities/IRushRepository.cs
@@ -7,6 +7,7 @@ public interface IRushRepository
 {
     Task<Rush?> GetSingleRushAsync(int rushId);
     Task<Rush?> CreateRushAsync(PlaySubmitDTO playSubmit);
+    Task<Rush?> CreateRushAsync(Rush newRush);
     Task<Rush?> UpdateRushAsync(PlaySubmitDTO playSubmit);
     Task<bool> DeleteRushAsync(int rushId);
 }

--- a/the-backfield/Interfaces/PlayEntities/ISafetyRepository.cs
+++ b/the-backfield/Interfaces/PlayEntities/ISafetyRepository.cs
@@ -7,6 +7,7 @@ namespace TheBackfield.Interfaces.PlayEntities
     {
         Task<Safety?> GetSingleSafetyAsync(int safetyId);
         Task<Safety?> CreateSafetyAsync(PlaySubmitDTO playSubmit);
+        Task<Safety?> CreateSafetyAsync(Safety newSafety);
         Task<Safety?> UpdateSafetyAsync(PlaySubmitDTO playSubmit);
         Task<bool> DeleteSafetyAsync(int safetyId);
     }

--- a/the-backfield/Interfaces/PlayEntities/ITackleRepository.cs
+++ b/the-backfield/Interfaces/PlayEntities/ITackleRepository.cs
@@ -5,5 +5,6 @@ namespace TheBackfield.Interfaces.PlayEntities;
 public interface ITackleRepository
 {
     Task<Tackle?> CreateTackleAsync(int playId, int tacklerId);
+    Task<Tackle?> CreateTackleAsync(Tackle newTackle);
     Task<bool> DeleteTackleAsync(int tackleId);
 }

--- a/the-backfield/Interfaces/PlayEntities/ITouchdownRepository.cs
+++ b/the-backfield/Interfaces/PlayEntities/ITouchdownRepository.cs
@@ -7,6 +7,7 @@ namespace TheBackfield.Interfaces.PlayEntities
     {
         Task<Touchdown?> GetSingleTouchdownAsync(int touchdownId);
         Task<Touchdown?> CreateTouchdownAsync(PlaySubmitDTO playSubmit);
+        Task<Touchdown?> CreateTouchdownAsync(Touchdown newTouchdown);
         Task<Touchdown?> UpdateTouchdownAsync(PlaySubmitDTO playSubmit);
         Task<bool> DeleteTouchdownAsync(int touchdownId);
     }

--- a/the-backfield/Repositories/PlayEntities/ConversionRepository.cs
+++ b/the-backfield/Repositories/PlayEntities/ConversionRepository.cs
@@ -73,6 +73,53 @@ public class ConversionRepository : IConversionRepository
         return newConversion;
     }
 
+    public async Task<Conversion?> CreateConversionAsync(Conversion newConversion)
+    {
+        Play? play = await _dbContext.Plays.FindAsync(newConversion.PlayId);
+        if (play == null)
+        {
+            return null;
+        }
+
+        if (newConversion.PasserId != null)
+        {
+            Player? passer = await _dbContext.Players.FindAsync(newConversion.PasserId);
+            if (passer == null)
+            {
+                return null;
+            }
+        }
+        if (newConversion.ReceiverId != null)
+        {
+            Player? receiver = await _dbContext.Players.FindAsync(newConversion.ReceiverId);
+            if (receiver == null)
+            {
+                return null;
+            }
+        }
+        if (newConversion.RusherId != null)
+        {
+            Player? rusher = await _dbContext.Players.FindAsync(newConversion.RusherId);
+            if (rusher == null)
+            {
+                return null;
+            }
+        }
+        if (newConversion.ReturnerId != null)
+        {
+            Player? returner = await _dbContext.Players.FindAsync(newConversion.ReturnerId);
+            if (returner == null)
+            {
+                return null;
+            }
+        }
+
+        _dbContext.Conversions.Add(newConversion);
+        await _dbContext.SaveChangesAsync();
+
+        return newConversion;
+    }
+
     public Task<bool> DeleteConversionAsync(int conversionId)
     {
         throw new NotImplementedException();

--- a/the-backfield/Repositories/PlayEntities/ExtraPointRepository.cs
+++ b/the-backfield/Repositories/PlayEntities/ExtraPointRepository.cs
@@ -54,6 +54,36 @@ public class ExtraPointRepository : IExtraPointRepository
 
         return newExtraPoint;
     }
+    public async Task<ExtraPoint?> CreateExtraPointAsync(ExtraPoint newExtraPoint)
+    {
+        Play? play = await _dbContext.Plays.FindAsync(newExtraPoint.PlayId);
+        if (play == null)
+        {
+            return null;
+        }
+
+        if (newExtraPoint.KickerId != null)
+        {
+            Player? kicker = await _dbContext.Players.FindAsync(newExtraPoint.KickerId);
+            if (kicker == null)
+            {
+                return null;
+            }
+        }
+        if (newExtraPoint.ReturnerId != null)
+        {
+            Player? returner = await _dbContext.Players.FindAsync(newExtraPoint.ReturnerId);
+            if (returner == null)
+            {
+                return null;
+            }
+        }
+
+        _dbContext.ExtraPoints.Add(newExtraPoint);
+        await _dbContext.SaveChangesAsync();
+
+        return newExtraPoint;
+    }
 
     public Task<bool> DeleteExtraPointAsync(int extraPointId)
     {

--- a/the-backfield/Repositories/PlayEntities/FieldGoalRepository.cs
+++ b/the-backfield/Repositories/PlayEntities/FieldGoalRepository.cs
@@ -46,6 +46,28 @@ public class FieldGoalRepository : IFieldGoalRepository
 
         return newFieldGoal;
     }
+    public async Task<FieldGoal?> CreateFieldGoalAsync(FieldGoal newFieldGoal)
+    {
+        Play? play = await _dbContext.Plays.FindAsync(newFieldGoal.PlayId);
+        if (play == null)
+        {
+            return null;
+        }
+
+        if (newFieldGoal.KickerId != null)
+        {
+            Player? kicker = await _dbContext.Players.FindAsync(newFieldGoal.KickerId);
+            if (kicker == null)
+            {
+                return null;
+            }
+        }
+
+        _dbContext.FieldGoals.Add(newFieldGoal);
+        await _dbContext.SaveChangesAsync();
+
+        return newFieldGoal;
+    }
 
     public Task<bool> DeleteFieldGoalAsync(int fieldGoalId)
     {

--- a/the-backfield/Repositories/PlayEntities/FumbleRepository.cs
+++ b/the-backfield/Repositories/PlayEntities/FumbleRepository.cs
@@ -67,6 +67,46 @@ public class FumbleRepository : IFumbleRepository
 
         return newFumble;
     }
+    public async Task<Fumble?> CreateFumbleAsync(Fumble newFumble)
+    {
+        Play? play = await _dbContext.Plays
+            .AsNoTracking()
+            .SingleOrDefaultAsync(p => p.Id == newFumble.PlayId);
+        if (play == null)
+        {
+            return null;
+        }
+
+        if (newFumble.FumbleCommittedById != null)
+        {
+            Player? fumbler = await _dbContext.Players.AsNoTracking().SingleOrDefaultAsync(p => p.Id == newFumble.FumbleCommittedById);
+            if (fumbler == null)
+            {
+                return null;
+            }
+        }
+        if (newFumble.FumbleForcedById != null)
+        {
+            Player? forcedBy = await _dbContext.Players.AsNoTracking().SingleOrDefaultAsync(p => p.Id == newFumble.FumbleForcedById);
+            if (forcedBy == null)
+            {
+                return null;
+            }
+        }
+        if (newFumble.FumbleRecoveredById != null)
+        {
+            Player? recoveredBy = await _dbContext.Players.AsNoTracking().SingleOrDefaultAsync(p => p.Id == newFumble.FumbleRecoveredById);
+            if (recoveredBy == null)
+            {
+                return null;
+            }
+        }
+
+        _dbContext.Fumbles.Add(newFumble);
+        await _dbContext.SaveChangesAsync();
+
+        return newFumble;
+    }
 
     public Task<bool> DeleteFumbleAsync(int fumbleId)
     {

--- a/the-backfield/Repositories/PlayEntities/InterceptionRepository.cs
+++ b/the-backfield/Repositories/PlayEntities/InterceptionRepository.cs
@@ -44,6 +44,28 @@ public class InterceptionRepository : IInterceptionRepository
 
         return newInterception;
     }
+    public async Task<Interception?> CreateInterceptionAsync(Interception newInterception)
+    {
+        Play? play = await _dbContext.Plays.FindAsync(newInterception.PlayId);
+        if (play == null)
+        {
+            return null;
+        }
+
+        if (newInterception.InterceptedById != null)
+        {
+            Player? defender = await _dbContext.Players.FindAsync(newInterception.InterceptedById);
+            if (defender == null)
+            {
+                return null;
+            }
+        }
+
+        _dbContext.Interceptions.Add(newInterception);
+        await _dbContext.SaveChangesAsync();
+
+        return newInterception;
+    }
 
     public Task<bool> DeleteInterceptionAsync(int interceptionId)
     {

--- a/the-backfield/Repositories/PlayEntities/KickBlockRepository.cs
+++ b/the-backfield/Repositories/PlayEntities/KickBlockRepository.cs
@@ -52,6 +52,36 @@ public class KickBlockRepository : IKickBlockRepository
 
         return newKickBlock;
     }
+    public async Task<KickBlock?> CreateKickBlockAsync(KickBlock newKickBlock)
+    {
+        Play? play = await _dbContext.Plays.FindAsync(newKickBlock.PlayId);
+        if (play == null)
+        {
+            return null;
+        }
+
+        if (newKickBlock.BlockedById != null)
+        {
+            Player? blocker = await _dbContext.Players.FindAsync(newKickBlock.BlockedById);
+            if (blocker == null)
+            {
+                return null;
+            }
+        }
+        if (newKickBlock.RecoveredById != null)
+        {
+            Player? recovery = await _dbContext.Players.FindAsync(newKickBlock.RecoveredById);
+            if (recovery == null)
+            {
+                return null;
+            }
+        }
+
+        _dbContext.KickBlocks.Add(newKickBlock);
+        await _dbContext.SaveChangesAsync();
+
+        return newKickBlock;
+    }
 
     public Task<bool> DeleteKickBlockAsync(int kickBlockId)
     {

--- a/the-backfield/Repositories/PlayEntities/KickoffRepository.cs
+++ b/the-backfield/Repositories/PlayEntities/KickoffRepository.cs
@@ -55,6 +55,37 @@ public class KickoffRepository : IKickoffRepository
 
         return newKickoff;
     }
+    public async Task<Kickoff?> CreateKickoffAsync(Kickoff newKickoff)
+    {
+        Play? play = await _dbContext.Plays.FindAsync(newKickoff.PlayId);
+        if (play == null)
+        {
+            return null;
+        }
+
+        if (newKickoff.KickerId != null)
+        {
+            Player? kicker = await _dbContext.Players.FindAsync(newKickoff.KickerId);
+            if (kicker == null)
+            {
+                return null;
+            }
+        }
+
+        if (newKickoff.ReturnerId != null)
+        {
+            Player? returner = await _dbContext.Players.FindAsync(newKickoff.ReturnerId);
+            if (returner == null)
+            {
+                return null;
+            }
+        }
+
+        _dbContext.Kickoffs.Add(newKickoff);
+        await _dbContext.SaveChangesAsync();
+
+        return newKickoff;
+    }
 
     public Task<bool> DeleteKickoffAsync(int kickoffId)
     {

--- a/the-backfield/Repositories/PlayEntities/LateralRepository.cs
+++ b/the-backfield/Repositories/PlayEntities/LateralRepository.cs
@@ -52,6 +52,33 @@ public class LateralRepository : ILateralRepository
 
         return newLateral;
     }
+    public async Task<Lateral?> CreateLateralAsync(Lateral newLateral)
+    {
+        Play? play = await _dbContext.Plays
+            .AsNoTracking()
+            .SingleOrDefaultAsync(p => p.Id == newLateral.PlayId);
+
+        if (play == null)
+        {
+            return null;
+        }
+
+        Player? prevCarrier = await _dbContext.Players.AsNoTracking().SingleOrDefaultAsync(p => p.Id == newLateral.PrevCarrierId);
+        if (prevCarrier == null)
+        {
+            return null;
+        }
+        Player? newCarrier = await _dbContext.Players.AsNoTracking().SingleOrDefaultAsync(p => p.Id == newLateral.NewCarrierId);
+        if (newCarrier == null)
+        {
+            return null;
+        }
+
+        _dbContext.Laterals.Add(newLateral);
+        await _dbContext.SaveChangesAsync();
+
+        return newLateral;
+    }
 
     public Task<bool> DeleteLateralAsync(int lateralId)
     {

--- a/the-backfield/Repositories/PlayEntities/PassRepository.cs
+++ b/the-backfield/Repositories/PlayEntities/PassRepository.cs
@@ -58,6 +58,37 @@ public class PassRepository : IPassRepository
 
         return newPass;
     }
+    public async Task<Pass?> CreatePassAsync(Pass newPass)
+    {
+        Play? play = await _dbContext.Plays
+            .AsNoTracking()
+            .SingleOrDefaultAsync(p => p.Id == newPass.PlayId);
+
+        if (play == null)
+        {
+            return null;
+        }
+
+        Player? passer = await _dbContext.Players.AsNoTracking().SingleOrDefaultAsync(p => p.Id == newPass.PasserId);
+        if (passer == null || passer.TeamId != play.TeamId)
+        {
+            return null;
+        }
+
+        if (newPass.ReceiverId != null)
+        {
+            Player? receiver = await _dbContext.Players.AsNoTracking().SingleOrDefaultAsync(p => p.Id == newPass.ReceiverId);
+            if (receiver == null || receiver.TeamId != play.TeamId)
+            {
+                return null;
+            }
+        }
+
+        _dbContext.Passes.Add(newPass);
+        await _dbContext.SaveChangesAsync();
+
+        return newPass;
+    }
 
     public Task<bool> DeletePassAsync(int passId)
     {

--- a/the-backfield/Repositories/PlayEntities/PuntRepository.cs
+++ b/the-backfield/Repositories/PlayEntities/PuntRepository.cs
@@ -56,6 +56,37 @@ public class PuntRepository : IPuntRepository
 
         return newPunt;
     }
+    public async Task<Punt?> CreatePuntAsync(Punt newPunt)
+    {
+        Play? play = await _dbContext.Plays.FindAsync(newPunt.PlayId);
+        if (play == null)
+        {
+            return null;
+        }
+
+        if (newPunt.KickerId != null)
+        {
+            Player? kicker = await _dbContext.Players.FindAsync(newPunt.KickerId);
+            if (kicker == null)
+            {
+                return null;
+            }
+        }
+
+        if (newPunt.ReturnerId != null)
+        {
+            Player? returner = await _dbContext.Players.FindAsync(newPunt.ReturnerId);
+            if (returner == null)
+            {
+                return null;
+            }
+        }
+
+        _dbContext.Punts.Add(newPunt);
+        await _dbContext.SaveChangesAsync();
+
+        return newPunt;
+    }
 
     public Task<bool> DeletePuntAsync(int puntId)
     {

--- a/the-backfield/Repositories/PlayEntities/RushRepository.cs
+++ b/the-backfield/Repositories/PlayEntities/RushRepository.cs
@@ -45,6 +45,27 @@ public class RushRepository : IRushRepository
 
         return newRush;
     }
+    public async Task<Rush?> CreateRushAsync(Rush newRush)
+    {
+        Play? play = await _dbContext.Plays
+            .AsNoTracking()
+            .SingleOrDefaultAsync(p => p.Id == newRush.PlayId);
+        if (play == null)
+        {
+            return null;
+        }
+
+        Player? rusher = await _dbContext.Players.AsNoTracking().SingleOrDefaultAsync(p => p.Id == newRush.RusherId);
+        if (rusher == null || rusher.TeamId != play.TeamId)
+        {
+            return null;
+        }
+
+        _dbContext.Rushes.Add(newRush);
+        await _dbContext.SaveChangesAsync();
+
+        return newRush;
+    }
 
     public Task<bool> DeleteRushAsync(int rushId)
     {

--- a/the-backfield/Repositories/PlayEntities/SafetyRepository.cs
+++ b/the-backfield/Repositories/PlayEntities/SafetyRepository.cs
@@ -46,6 +46,32 @@ namespace TheBackfield.Repositories.PlayEntities
             return newSafety;
         }
 
+        public async Task<Safety?> CreateSafetyAsync(Safety newSafety)
+        {
+            Play? play = await _dbContext.Plays
+                .AsNoTracking()
+                .Include(p => p.Game)
+                .SingleOrDefaultAsync(p => p.Id == newSafety.PlayId);
+            if (play == null || play.Game == null)
+            {
+                return null;
+            }
+
+            if (newSafety.CedingPlayerId != null)
+            {
+                Player? ceding = await _dbContext.Players.AsNoTracking().SingleOrDefaultAsync(p => p.Id == newSafety.CedingPlayerId);
+                if (ceding == null || !new int[] { play.Game.HomeTeamId, play.Game.AwayTeamId }.Contains(ceding.TeamId))
+                {
+                    return null;
+                }
+            }
+
+            _dbContext.Safeties.Add(newSafety);
+            await _dbContext.SaveChangesAsync();
+
+            return newSafety;
+        }
+
         public Task<bool> DeleteSafetyAsync(int safetyId)
         {
             throw new NotImplementedException();

--- a/the-backfield/Repositories/PlayEntities/TackleRepository.cs
+++ b/the-backfield/Repositories/PlayEntities/TackleRepository.cs
@@ -42,6 +42,28 @@ public class TackleRepository : ITackleRepository
 
         return newTackle;
     }
+    public async Task<Tackle?> CreateTackleAsync(Tackle newTackle)
+    {
+        Play? play = await _dbContext.Plays
+            .AsNoTracking()
+            .Include(p => p.Game)
+            .SingleOrDefaultAsync(p => p.Id == newTackle.PlayId);
+        if (play == null || play.Game == null)
+        {
+            return null;
+        }
+
+        Player? tackler = await _dbContext.Players.AsNoTracking().SingleOrDefaultAsync(p => p.Id == newTackle.TacklerId);
+        if (tackler == null || !new int[] { play.Game.HomeTeamId, play.Game.AwayTeamId }.Contains(tackler.TeamId))
+        {
+            return null;
+        }
+
+        _dbContext.Tackles.Add(newTackle);
+        await _dbContext.SaveChangesAsync();
+
+        return newTackle;
+    }
 
     public Task<bool> DeleteTackleAsync(int tackleId)
     {

--- a/the-backfield/Repositories/PlayEntities/TouchdownRepository.cs
+++ b/the-backfield/Repositories/PlayEntities/TouchdownRepository.cs
@@ -45,6 +45,31 @@ namespace TheBackfield.Repositories.PlayEntities
 
             return newTouchdown;
         }
+        public async Task<Touchdown?> CreateTouchdownAsync(Touchdown newTouchdown)
+        {
+            Play? play = await _dbContext.Plays
+                .AsNoTracking()
+                .Include(p => p.Game)
+                .SingleOrDefaultAsync(p => p.Id == newTouchdown.PlayId);
+            if (play == null || play.Game == null)
+            {
+                return null;
+            }
+
+            if (newTouchdown.PlayerId != null)
+            {
+                Player? player = await _dbContext.Players.AsNoTracking().SingleOrDefaultAsync(p => p.Id == newTouchdown.PlayerId);
+                if (player == null || !new int[] { play.Game.HomeTeamId, play.Game.AwayTeamId }.Contains(player.TeamId))
+                {
+                    return null;
+                }
+            }
+
+            _dbContext.Touchdowns.Add(newTouchdown);
+            await _dbContext.SaveChangesAsync();
+
+            return newTouchdown;
+        }
 
         public Task<bool> DeleteTouchdownAsync(int touchdownId)
         {


### PR DESCRIPTION
Added a second implementation of [PlayAux]Repository.Create[PlayAux]Async() that accept a [PlayAux] entity to add to the database, rather than converting from a PlaySubmitDTO.

This allows calculated stats to be entered on initial creation rather than having to do another update trip (or passing calculated stats separately into methods)

This is part of the larger milestone to have player stats calculated from play data.