### PR TITLE
Created PlaySubmitDTOAsPlay method

### DIFF
--- a/the-backfield/Interfaces/IPlayService.cs
+++ b/the-backfield/Interfaces/IPlayService.cs
@@ -1,6 +1,7 @@
 ﻿using TheBackfield.DTOs;
 using TheBackfield.DTOs.GameStream;
 using TheBackfield.Models;
+using TheBackfield.Models.PlayEntities;
 
 namespace TheBackfield.Interfaces
 {


### PR DESCRIPTION
Address #119 

PlayService.PlaySubmitDTOAsPlay() private method to convert a PlaySubmitDTO to a Play with its associated entities.

Method is invoked within PlayService.CreatePlayAsync() but data is not yet incorporated into creation process. (Will be addressed by #120 ). Invocation however allows for test on normal play creation with breakpoints, for comparison to createdPlay at end of CreatePlayAsync method.