### PR TITLE
Populate Play Aux Extra Stats

### DIFF
--- a/the-backfield/Migrations/20250119084309_LateralYardage.Designer.cs
+++ b/the-backfield/Migrations/20250119084309_LateralYardage.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TheBackfield.Data;
@@ -11,9 +12,10 @@ using TheBackfield.Data;
 namespace the_backfield.Migrations
 {
     [DbContext(typeof(TheBackfieldDbContext))]
-    partial class TheBackfieldDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250119084309_LateralYardage")]
+    partial class LateralYardage
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/the-backfield/Migrations/20250119084309_LateralYardage.cs
+++ b/the-backfield/Migrations/20250119084309_LateralYardage.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace the_backfield.Migrations
+{
+    public partial class LateralYardage : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "Yardage",
+                table: "Laterals",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Yardage",
+                table: "Laterals");
+        }
+    }
+}

--- a/the-backfield/Models/PlayEntities/Lateral.cs
+++ b/the-backfield/Models/PlayEntities/Lateral.cs
@@ -14,6 +14,7 @@ namespace TheBackfield.Models.PlayEntities
         public Player NewCarrier { get; set; }
         public int? PossessionAt { get; set; }
         public int? CarriedTo { get; set; }
+        public int Yardage { get; set; }
         public string YardageType { get; set; } = "";
     }
 }

--- a/the-backfield/Utilities/StatClient.cs
+++ b/the-backfield/Utilities/StatClient.cs
@@ -396,14 +396,14 @@ namespace TheBackfield.Utilities
                     EntityId = play.Rush.Id,
                 });
             }
-            if (possessionChanges[possessionChanges.Count() - 1].ToPlayerId != 0)
+            if (possessionChanges[^1].ToPlayerId != 0)
             {
                 possessionChanges.Add(new()
                 {
-                    FromPlayerId = possessionChanges[possessionChanges.Count() - 1].ToPlayerId,
+                    FromPlayerId = possessionChanges[^1].ToPlayerId,
                     FromPlayerAt = play.FieldPositionEnd,
-                    EntityType = possessionChanges[possessionChanges.Count() - 1].EntityType,
-                    EntityId = possessionChanges[possessionChanges.Count() - 1].EntityId,
+                    EntityType = possessionChanges[^1].EntityType,
+                    EntityId = possessionChanges[^1].EntityId,
                 });
             }
 


### PR DESCRIPTION
Address #121 

Extra stats on play aux entities (i.e. Yardage, ReturnYardage, YardageType, etc.) are calculated during play creation via call to PlayService.CalculatePlayStatsAsync(), which includes call to retrieve the possession chain. In a similar, albeit diluted, manner to the way the possession chain is converted into play segments, CalculatePlayStatsAsync() analyzes the possession chain and adds extra stats to many of the Play Aux entities, if necessary. This calculation is intended to be done any time a play and/or its associated auxiliaries is/are created or updated. Storing this data on the entities lessens the computation that must be done any time a call is made to retrieve player stats, such as is planned for the Player Info pages and the GameStream update.

**Requires an ef database update on pull** (due to addition of Yardage property to Lateral model)