### PR TITLE
Compile Player Stats from list of plays

### DIFF
--- a/the-backfield/DTOs/GameStream/GameStreamDTO.cs
+++ b/the-backfield/DTOs/GameStream/GameStreamDTO.cs
@@ -12,8 +12,10 @@ namespace TheBackfield.DTOs.GameStream
             _nextPlay = nextPlay;
         }
         public Team? HomeTeam { get { return _game.HomeTeam; } }
+        public List<PlayerStatsDTO> HomeTeamPlayerStats { get; set; } = [];
         public int HomeTeamScore { get; set; }
         public Team? AwayTeam { get { return _game.AwayTeam; } }
+        public List<PlayerStatsDTO> AwayTeamPlayerStats { get; set; } = [];
         public int AwayTeamScore { get; set; }
         public int DrivePlays { get; set; }
         public int? DrivePositionStart { get; set; }

--- a/the-backfield/DTOs/PlayerStatsDTO.cs
+++ b/the-backfield/DTOs/PlayerStatsDTO.cs
@@ -4,6 +4,8 @@ namespace TheBackfield.DTOs
 {
     public class PlayerStatsDTO
     {
+        public int PlayerId { get; set; }
+        public Player? PlayerInfo { get; set; }
         public int PassAttempts { get; set; }
         public int PassCompletions { get; set; }
         public int PassYards { get; set; }
@@ -20,7 +22,7 @@ namespace TheBackfield.DTOs
         public int Tackles { get; set; }
         public int SoloTackles { get; set; }
         public int TacklesForLoss { get; set; }
-        public int Sacks { get; set; }
+        public double Sacks { get; set; }
         public int InterceptionsReceived { get; set; }
         public int InterceptionReturnYards { get; set; }
         public int InterceptionReturnTouchdowns { get; set; }

--- a/the-backfield/DTOs/PlayerStatsDTO.cs
+++ b/the-backfield/DTOs/PlayerStatsDTO.cs
@@ -4,8 +4,6 @@ namespace TheBackfield.DTOs
 {
     public class PlayerStatsDTO
     {
-        public int PlayerId { get; set; }
-        public Player Player { get; set; } = new();
         public int PassAttempts { get; set; }
         public int PassCompletions { get; set; }
         public int PassYards { get; set; }

--- a/the-backfield/Models/Player.cs
+++ b/the-backfield/Models/Player.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using TheBackfield.DTOs;
 
 namespace TheBackfield.Models;
 
@@ -17,6 +18,7 @@ public class Player
     [Required]
     public int UserId { get; set; }
     public List<Position> Positions { get; set; } = [];
+    public PlayerStatsDTO Stats { get; set; } = new();
 
     public string Name()
     {

--- a/the-backfield/Models/Player.cs
+++ b/the-backfield/Models/Player.cs
@@ -1,5 +1,4 @@
 using System.ComponentModel.DataAnnotations;
-using TheBackfield.DTOs;
 
 namespace TheBackfield.Models;
 
@@ -18,7 +17,6 @@ public class Player
     [Required]
     public int UserId { get; set; }
     public List<Position> Positions { get; set; } = [];
-    public PlayerStatsDTO Stats { get; set; } = new();
 
     public string Name()
     {


### PR DESCRIPTION
Address #126 

StatClient.ParsePlayerStats() receives a list of plays and compiles a List<PlayerStatsDTO> from those plays. Each player to log a stat has one PlayerStatsDTO with all stats from that list of plays

**ParsePlayerStats currently lacks functionality to handle TacklesForLoss and PassingTouchdowns, as well as parsing of return yardage on fumbles/laterals** Beneficial to add TeamId on all Play Auxs for attached players (future issue). Also need more variation in ReturnType properties to sort yardage into category.

GameStreamDTO has properties to hold Lists of PlayerStats for both teams.

GetGameStream calls ParsePlayerStats(), adds the players to the PlayerStatsDTO in the PlayerInfo properties, and sorts each DTO into either team (HomeTeamPlayersStats or AwayTeamPlayerStats) on the GameStreamDTO.

**Note that stats are only calculated on creation/update, any plays added prior to PR #125 will not be included in PlayerStats**