### PR TITLE
TeamIds on Play Aux with addition at Play Creation

### DIFF
--- a/the-backfield/Migrations/20250120205047_AuxTeamIds.Designer.cs
+++ b/the-backfield/Migrations/20250120205047_AuxTeamIds.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TheBackfield.Data;
@@ -11,9 +12,10 @@ using TheBackfield.Data;
 namespace the_backfield.Migrations
 {
     [DbContext(typeof(TheBackfieldDbContext))]
-    partial class TheBackfieldDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250120205047_AuxTeamIds")]
+    partial class AuxTeamIds
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/the-backfield/Migrations/20250120205047_AuxTeamIds.cs
+++ b/the-backfield/Migrations/20250120205047_AuxTeamIds.cs
@@ -1,0 +1,329 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace the_backfield.Migrations
+{
+    public partial class AuxTeamIds : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "TeamId",
+                table: "Touchdowns",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "TeamId",
+                table: "Tackles",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "CedingTeamId",
+                table: "Safeties",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "TeamId",
+                table: "Rushes",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "ReturnTeamId",
+                table: "Punts",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "TeamId",
+                table: "Punts",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "TeamId",
+                table: "Passes",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "TeamId",
+                table: "PassDefenses",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "PrevCarrierId",
+                table: "Laterals",
+                type: "integer",
+                nullable: true,
+                oldClrType: typeof(int),
+                oldType: "integer");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "NewCarrierId",
+                table: "Laterals",
+                type: "integer",
+                nullable: true,
+                oldClrType: typeof(int),
+                oldType: "integer");
+
+            migrationBuilder.AddColumn<int>(
+                name: "TeamId",
+                table: "Laterals",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "ReturnTeamId",
+                table: "Kickoffs",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "TeamId",
+                table: "Kickoffs",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "BlockedByTeamId",
+                table: "KickBlocks",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "RecoveredByTeamId",
+                table: "KickBlocks",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "InterceptedById",
+                table: "Interceptions",
+                type: "integer",
+                nullable: true,
+                oldClrType: typeof(int),
+                oldType: "integer");
+
+            migrationBuilder.AddColumn<int>(
+                name: "TeamId",
+                table: "Interceptions",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "FumbleCommittedById",
+                table: "Fumbles",
+                type: "integer",
+                nullable: true,
+                oldClrType: typeof(int),
+                oldType: "integer");
+
+            migrationBuilder.AddColumn<int>(
+                name: "FumbleCommittedByTeamId",
+                table: "Fumbles",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "FumbleForcedByTeamId",
+                table: "Fumbles",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "FumbleRecoveredByTeamId",
+                table: "Fumbles",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "TeamId",
+                table: "FieldGoals",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "ReturnTeamId",
+                table: "ExtraPoints",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "TeamId",
+                table: "ExtraPoints",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "ReturnTeamId",
+                table: "Conversions",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "TeamId",
+                table: "Conversions",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "TeamId",
+                table: "Touchdowns");
+
+            migrationBuilder.DropColumn(
+                name: "TeamId",
+                table: "Tackles");
+
+            migrationBuilder.DropColumn(
+                name: "CedingTeamId",
+                table: "Safeties");
+
+            migrationBuilder.DropColumn(
+                name: "TeamId",
+                table: "Rushes");
+
+            migrationBuilder.DropColumn(
+                name: "ReturnTeamId",
+                table: "Punts");
+
+            migrationBuilder.DropColumn(
+                name: "TeamId",
+                table: "Punts");
+
+            migrationBuilder.DropColumn(
+                name: "TeamId",
+                table: "Passes");
+
+            migrationBuilder.DropColumn(
+                name: "TeamId",
+                table: "PassDefenses");
+
+            migrationBuilder.DropColumn(
+                name: "TeamId",
+                table: "Laterals");
+
+            migrationBuilder.DropColumn(
+                name: "ReturnTeamId",
+                table: "Kickoffs");
+
+            migrationBuilder.DropColumn(
+                name: "TeamId",
+                table: "Kickoffs");
+
+            migrationBuilder.DropColumn(
+                name: "BlockedByTeamId",
+                table: "KickBlocks");
+
+            migrationBuilder.DropColumn(
+                name: "RecoveredByTeamId",
+                table: "KickBlocks");
+
+            migrationBuilder.DropColumn(
+                name: "TeamId",
+                table: "Interceptions");
+
+            migrationBuilder.DropColumn(
+                name: "FumbleCommittedByTeamId",
+                table: "Fumbles");
+
+            migrationBuilder.DropColumn(
+                name: "FumbleForcedByTeamId",
+                table: "Fumbles");
+
+            migrationBuilder.DropColumn(
+                name: "FumbleRecoveredByTeamId",
+                table: "Fumbles");
+
+            migrationBuilder.DropColumn(
+                name: "TeamId",
+                table: "FieldGoals");
+
+            migrationBuilder.DropColumn(
+                name: "ReturnTeamId",
+                table: "ExtraPoints");
+
+            migrationBuilder.DropColumn(
+                name: "TeamId",
+                table: "ExtraPoints");
+
+            migrationBuilder.DropColumn(
+                name: "ReturnTeamId",
+                table: "Conversions");
+
+            migrationBuilder.DropColumn(
+                name: "TeamId",
+                table: "Conversions");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "PrevCarrierId",
+                table: "Laterals",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0,
+                oldClrType: typeof(int),
+                oldType: "integer",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "NewCarrierId",
+                table: "Laterals",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0,
+                oldClrType: typeof(int),
+                oldType: "integer",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "InterceptedById",
+                table: "Interceptions",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0,
+                oldClrType: typeof(int),
+                oldType: "integer",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "FumbleCommittedById",
+                table: "Fumbles",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0,
+                oldClrType: typeof(int),
+                oldType: "integer",
+                oldNullable: true);
+        }
+    }
+}

--- a/the-backfield/Models/PlayEntities/Conversion.cs
+++ b/the-backfield/Models/PlayEntities/Conversion.cs
@@ -7,16 +7,18 @@ namespace TheBackfield.Models.PlayEntities
         public int Id { get; set; }
         [Required]
         public int PlayId { get; set; }
-        public Play Play { get; set; }
+        public Play? Play { get; set; }
         public int? PasserId { get; set; } = null;
         public Player? Passer { get; set; }
         public int? ReceiverId { get; set; } = null;
         public Player? Receiver { get; set; }
         public int? RusherId { get; set; } = null;
         public Player? Rusher { get; set; }
+        public int TeamId { get; set; }
         public bool Good { get; set; }
         public bool DefensiveConversion { get; set; }
         public int? ReturnerId { get; set; } = null;
         public Player? Returner { get; set; }
+        public int ReturnTeamId { get; set; }
     }
 }

--- a/the-backfield/Models/PlayEntities/ExtraPoint.cs
+++ b/the-backfield/Models/PlayEntities/ExtraPoint.cs
@@ -7,13 +7,15 @@ namespace TheBackfield.Models.PlayEntities
         public int Id { get; set; }
         [Required]
         public int PlayId { get; set; }
-        public Play Play { get; set; }
+        public Play? Play { get; set; }
         public int? KickerId { get; set; } = null;
         public Player? Kicker { get; set; }
+        public int TeamId { get; set; }
         public bool Good { get; set; }
         public bool Fake { get; set; }
         public bool DefensiveConversion { get; set; }
         public int? ReturnerId { get; set; } = null;
         public Player? Returner { get; set; }
+        public int ReturnTeamId { get; set; }
     }
 }

--- a/the-backfield/Models/PlayEntities/FieldGoal.cs
+++ b/the-backfield/Models/PlayEntities/FieldGoal.cs
@@ -10,6 +10,7 @@ namespace TheBackfield.Models.PlayEntities
         public Play? Play { get; set; }
         public int? KickerId { get; set; } = null;
         public Player? Kicker { get; set; }
+        public int TeamId { get; set; }
         public bool Good { get; set; }
         public bool Fake { get; set; }
         public int Distance { get; set; }

--- a/the-backfield/Models/PlayEntities/Fumble.cs
+++ b/the-backfield/Models/PlayEntities/Fumble.cs
@@ -7,14 +7,17 @@ namespace TheBackfield.Models.PlayEntities
         public int Id { get; set; }
         [Required]
         public int PlayId { get; set; }
-        public Play Play { get; set; }
+        public Play? Play { get; set; }
         public int? FumbleCommittedById { get; set; } = null;
-        public Player FumbleCommittedBy { get; set; }
+        public Player? FumbleCommittedBy { get; set; }
+        public int FumbleCommittedByTeamId { get; set; }
         public int? FumbledAt { get; set; }
         public int? FumbleForcedById { get; set; } = null;
         public Player? FumbleForcedBy { get; set; }
+        public int FumbleForcedByTeamId { get; set; }
         public int? FumbleRecoveredById { get; set; } = null;
         public Player? FumbleRecoveredBy { get; set; }
+        public int FumbleRecoveredByTeamId { get; set; }
         public int? RecoveredAt { get; set; }
         public int LooseBallYardage { get; set; }
         public int ReturnYardage { get; set; }

--- a/the-backfield/Models/PlayEntities/Interception.cs
+++ b/the-backfield/Models/PlayEntities/Interception.cs
@@ -7,9 +7,10 @@ namespace TheBackfield.Models.PlayEntities
         public int Id { get; set; }
         [Required]
         public int PlayId { get; set; }
-        public Play Play { get; set; }
+        public Play? Play { get; set; }
         public int? InterceptedById { get; set; } = null;
-        public Player InterceptedBy { get; set; }
+        public Player? InterceptedBy { get; set; }
+        public int TeamId { get; set; }
         public int? InterceptedAt { get; set; }
         public int ReturnYardage { get; set; }
     }

--- a/the-backfield/Models/PlayEntities/KickBlock.cs
+++ b/the-backfield/Models/PlayEntities/KickBlock.cs
@@ -7,11 +7,13 @@ namespace TheBackfield.Models.PlayEntities
         public int Id { get; set; }
         [Required]
         public int PlayId { get; set; }
-        public Play Play { get; set; }
+        public Play? Play { get; set; }
         public int? BlockedById { get; set; } = null;
         public Player? BlockedBy { get; set; }
+        public int BlockedByTeamId { get; set; }
         public int? RecoveredById { get; set; } = null;
         public Player? RecoveredBy { get; set; }
+        public int RecoveredByTeamId { get; set; }
         public int? RecoveredAt { get; set; }
         public int LooseBallYardage { get; set; }
         public int ReturnYardage { get; set; }

--- a/the-backfield/Models/PlayEntities/Kickoff.cs
+++ b/the-backfield/Models/PlayEntities/Kickoff.cs
@@ -7,11 +7,13 @@ namespace TheBackfield.Models.PlayEntities
         public int Id { get; set; }
         [Required]
         public int PlayId { get; set; }
-        public Play Play { get; set; }
+        public Play? Play { get; set; }
         public int? KickerId { get; set; } = null;
         public Player? Kicker { get; set; }
+        public int TeamId { get; set; }
         public int? ReturnerId { get; set; } = null;
         public Player? Returner { get; set; }
+        public int ReturnTeamId { get; set; }
         public int? FieldedAt { get; set; } = null;
         public bool Touchback { get; set; }
         public int Distance { get; set; }

--- a/the-backfield/Models/PlayEntities/Lateral.cs
+++ b/the-backfield/Models/PlayEntities/Lateral.cs
@@ -7,11 +7,12 @@ namespace TheBackfield.Models.PlayEntities
         public int Id { get; set; }
         [Required]
         public int PlayId { get; set; }
-        public Play Play { get; set; }
+        public Play? Play { get; set; }
         public int? PrevCarrierId { get; set; } = null;
-        public Player PrevCarrier { get; set; }
+        public Player? PrevCarrier { get; set; }
         public int? NewCarrierId { get; set; } = null;
-        public Player NewCarrier { get; set; }
+        public Player? NewCarrier { get; set; }
+        public int TeamId { get; set; }
         public int? PossessionAt { get; set; }
         public int? CarriedTo { get; set; }
         public int Yardage { get; set; }

--- a/the-backfield/Models/PlayEntities/Pass.cs
+++ b/the-backfield/Models/PlayEntities/Pass.cs
@@ -7,11 +7,12 @@ namespace TheBackfield.Models.PlayEntities
         public int Id { get; set; }
         [Required]
         public int PlayId { get; set; }
-        public Play Play { get; set; }
+        public Play? Play { get; set; }
         public int? PasserId { get; set; } = null;
         public Player? Passer { get; set; }
         public int? ReceiverId { get; set; } = null;
         public Player? Receiver { get; set; }
+        public int TeamId { get; set; }
         public bool Completion { get; set; } = false;
         public int PassYardage { get; set; }
         public int ReceptionYardage { get; set; }

--- a/the-backfield/Models/PlayEntities/PassDefense.cs
+++ b/the-backfield/Models/PlayEntities/PassDefense.cs
@@ -7,8 +7,9 @@ namespace TheBackfield.Models.PlayEntities
         public int Id { get; set; }
         [Required]
         public int PlayId { get; set; }
-        public Play Play { get; set; }
+        public Play? Play { get; set; }
         public int? DefenderId { get; set; } = null;
         public Player? Defender { get; set; }
+        public int TeamId { get; set; }
     }
 }

--- a/the-backfield/Models/PlayEntities/Punt.cs
+++ b/the-backfield/Models/PlayEntities/Punt.cs
@@ -10,8 +10,10 @@ namespace TheBackfield.Models.PlayEntities
         public Play? Play { get; set; }
         public int? KickerId { get; set; } = null;
         public Player? Kicker { get; set; }
+        public int TeamId { get; set; }
         public int? ReturnerId { get; set; } = null;
         public Player? Returner { get; set; }
+        public int ReturnTeamId { get; set; }
         public int? FieldedAt { get; set; } = null;
         public bool FairCatch { get; set; }
         public bool Touchback { get; set; }

--- a/the-backfield/Models/PlayEntities/Rush.cs
+++ b/the-backfield/Models/PlayEntities/Rush.cs
@@ -7,9 +7,10 @@ namespace TheBackfield.Models.PlayEntities
         public int Id { get; set; }
         [Required]
         public int PlayId { get; set; }
-        public Play Play { get; set; }
+        public Play? Play { get; set; }
         public int? RusherId { get; set; } = null;
         public Player? Rusher { get; set; }
+        public int TeamId { get; set; }
         public int Yardage { get; set; }
     }
 }

--- a/the-backfield/Models/PlayEntities/Safety.cs
+++ b/the-backfield/Models/PlayEntities/Safety.cs
@@ -10,5 +10,6 @@ namespace TheBackfield.Models.PlayEntities
         public Play? Play { get; set; }
         public int? CedingPlayerId { get; set; } = null;
         public Player? CedingPlayer { get; set; }
+        public int CedingTeamId { get; set; }
     }
 }

--- a/the-backfield/Models/PlayEntities/Tackle.cs
+++ b/the-backfield/Models/PlayEntities/Tackle.cs
@@ -7,8 +7,9 @@ namespace TheBackfield.Models.PlayEntities
         public int Id { get; set; }
         [Required]
         public int PlayId { get; set; }
-        public Play Play { get; set; }
+        public Play? Play { get; set; }
         public int? TacklerId { get; set; } = null;
         public Player? Tackler { get; set; }
+        public int TeamId { get; set; }
     }
 }

--- a/the-backfield/Models/PlayEntities/Touchdown.cs
+++ b/the-backfield/Models/PlayEntities/Touchdown.cs
@@ -10,5 +10,6 @@ namespace TheBackfield.Models.PlayEntities
         public Play? Play { get; set; }
         public int? PlayerId { get; set; } = null;
         public Player? Player { get; set; }
+        public int TeamId { get; set; }
     }
 }


### PR DESCRIPTION
Address #128 

PlayAux Entities carry TeamIds for players listed in the Entity

PlayService.AddPlayAuxTeamIdsAsync() populates these TeamIds from play/player data. Only the home or away team ids as input into the method are allowed as possible ids. This way, if calculated against old data where players are removed or change teams, TeamIds are calculated against play situation (if possible) or left as 0 (if unable to determine team). Functionality could be improved by addition of many-to-many between players and teams, where join entity carries time information and the player's team can be deduced from time. Would require input of entire Game entity, not just team Ids.

AddPlayAuxTeamIdsAsync() is called on play creation.

Test by creating plays with various aux entities and checking in pgAdmin for correct TeamIds.

**Requires dotnet ef database update on pull**