### PR TITLE
Calculation of passTouchdowns and TacklesForLoss

### DIFF
--- a/the-backfield/Services/PlayService.cs
+++ b/the-backfield/Services/PlayService.cs
@@ -1,6 +1,4 @@
-﻿using Microsoft.EntityFrameworkCore.Metadata.Internal;
-using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
-using TheBackfield.DTOs;
+﻿using TheBackfield.DTOs;
 using TheBackfield.DTOs.GameStream;
 using TheBackfield.DTOs.PlayEntities;
 using TheBackfield.Interfaces;


### PR DESCRIPTION
Completion of #125 

Add calculation of PassTouchdowns and TacklesForLoss in StatClient.ParsePlayerStats() (benefitted by #128 with addition of TeamIds)