### PR TITLE
Defensive Conversion Counted in Score Calculation

### DIFF
--- a/the-backfield/Interfaces/IPlayService.cs
+++ b/the-backfield/Interfaces/IPlayService.cs
@@ -1,7 +1,5 @@
 ﻿using TheBackfield.DTOs;
-using TheBackfield.DTOs.GameStream;
 using TheBackfield.Models;
-using TheBackfield.Models.PlayEntities;
 
 namespace TheBackfield.Interfaces
 {

--- a/the-backfield/Services/GameStreamService.cs
+++ b/the-backfield/Services/GameStreamService.cs
@@ -736,7 +736,7 @@ namespace TheBackfield.Services
                 if ((play.ExtraPoint?.DefensiveConversion ?? false) || (play.Conversion?.DefensiveConversion ?? false))
                 {
                     Player? returner = play.ExtraPoint?.Returner != null ? play.ExtraPoint.Returner : play.Conversion?.Returner;
-                    segment.SegmentText += $" Returned by {(returner != null ? returner : teamsInv[segment.TeamId])} for defensive conversion.";
+                    segment.SegmentText += $" Returned by {(returner != null ? returner.Name() : teamsInv[segment.TeamId])} for defensive conversion.";
                 }
             }
 


### PR DESCRIPTION
Address bug #130 

Fixed logic gate in StatClient.ParseScore() that checked twice for defensive conversions on extra points instead of checking on both extra points and conversions, probably a copy/paste that was not edited.

Fixed additional bug in GameStreamService.GetPlaySegments() that attempted to print Player entity for defensive conversion player (output as "TheBackfield.Models.Player") instead of the player's name.

Removed unused using statements