### PR TITLE
Fixed bug preventing missed FGs

### DIFF
--- a/the-backfield/Services/PlayService.cs
+++ b/the-backfield/Services/PlayService.cs
@@ -926,9 +926,17 @@ namespace TheBackfield.Services
 
             if (hasPossession.Count == 0)
             {
-                if (playSubmit.FieldGoal && playSubmit.KickGood)
+                if (playSubmit.FieldGoal)
                 {
-                    return (playSubmit.TeamId, false);
+                    if (playSubmit.KickGood)
+                    {
+                        return (playSubmit.TeamId, false);
+                    }
+                    // If it was not a good kick, not a blocked kick, and not a faked kick, turnover to other team
+                    else if (!playSubmit.KickGood && !playSubmit.KickBlocked && !playSubmit.KickFake)
+                    {
+                        return (playSubmit.TeamId == homeTeamId ? awayTeamId : homeTeamId, false);
+                    }
                 }
                 FumbleSubmitDTO? notRecovered = playSubmit.Fumbles.SingleOrDefault(f => f.FumbleRecoveredById == null);
                 if (notRecovered != null)

--- a/the-backfield/Utilities/StatClient.cs
+++ b/the-backfield/Utilities/StatClient.cs
@@ -137,8 +137,10 @@ namespace TheBackfield.Utilities
             }
             else
             {
-                // If the play was a kickoff or punt, possession changes
-                if (play.Kickoff != null || (play.Punt != null && !play.Punt.Fake))
+                // If the play was a kickoff or punt or missed field goal, possession changes
+                if (play.Kickoff != null
+                    || (play.Punt != null && !play.Punt.Fake)
+                    || (play.FieldGoal != null && !play.FieldGoal.Fake && !play.FieldGoal.Good))
                 {
                     teamId = teamId == homeTeamId ? awayTeamId : homeTeamId;
                 }


### PR DESCRIPTION
Address #136 

Data validation did not have an allowance for missed field goals, as PlayService.VerifyPossessionChainAsync() would return that it was unable to determine the possession. Added logic to accept missed field goals and return the non-kicking team as the possession team. (NOTE: Suggestion to deprecate VerifyPossessionChainAsync() as logic is very similar to StatClient.ParseNextFieldPosition() and StatClient.GetPossessionChain() methods, perhaps so refactoring could eliminate the need for one, make data validation easier to manage).

Uncovered additional error where missed field goals would not result in change of possession unless forced by turnover on downs. Added logic to StatClient.ParseNextFieldPosition() for change (still checks for kick blocks and fumbles that may result in kicking team retaining possession, adjusts accordingly).