### PR TITLE
Update & Delete Repository methods for Play & Play Auxiliaries

### DIFF
--- a/the-backfield/Interfaces/IPlayRepository.cs
+++ b/the-backfield/Interfaces/IPlayRepository.cs
@@ -10,7 +10,7 @@ namespace TheBackfield.Interfaces
         Task<List<Play>> GetCurrentDriveByGameAsync(int gameId);
         Task<Play?> GetLastPlayByGameAsync(int gameId);
         Task<Play?> CreatePlayAsync(PlaySubmitDTO playSubmit);
-        Task<Play?> UpdatePlayAsync(PlaySubmitDTO playSubmit);
+        Task<Play?> UpdatePlayAsync(PlaySubmitDTO playUpdate);
         Task<string?> DeletePlayAsync(int playId);
     }
 }

--- a/the-backfield/Interfaces/PlayEntities/IConversionRepository.cs
+++ b/the-backfield/Interfaces/PlayEntities/IConversionRepository.cs
@@ -8,6 +8,6 @@ public interface IConversionRepository
     Task<Conversion?> GetSingleConversionAsync(int conversionId);
     Task<Conversion?> CreateConversionAsync(PlaySubmitDTO playSubmit);
     Task<Conversion?> CreateConversionAsync(Conversion newConversion);
-    Task<Conversion?> UpdateConversionAsync(PlaySubmitDTO playSubmit);
-    Task<bool> DeleteConversionAsync(int conversionId);
+    Task<Conversion?> UpdateConversionAsync(Conversion conversionUpdate);
+    Task<string?> DeleteConversionAsync(int conversionId);
 }

--- a/the-backfield/Interfaces/PlayEntities/IExtraPointRepository.cs
+++ b/the-backfield/Interfaces/PlayEntities/IExtraPointRepository.cs
@@ -8,6 +8,6 @@ public interface IExtraPointRepository
     Task<ExtraPoint?> GetSingleExtraPointAsync(int extraPointId);
     Task<ExtraPoint?> CreateExtraPointAsync(PlaySubmitDTO playSubmit);
     Task<ExtraPoint?> CreateExtraPointAsync(ExtraPoint newExtraPoint);
-    Task<ExtraPoint?> UpdateExtraPointAsync(PlaySubmitDTO playSubmit);
-    Task<bool> DeleteExtraPointAsync(int extraPointId);
+    Task<ExtraPoint?> UpdateExtraPointAsync(ExtraPoint extraPointUpdate);
+    Task<string?> DeleteExtraPointAsync(int extraPointId);
 }

--- a/the-backfield/Interfaces/PlayEntities/IFieldGoalRepository.cs
+++ b/the-backfield/Interfaces/PlayEntities/IFieldGoalRepository.cs
@@ -8,6 +8,6 @@ public interface IFieldGoalRepository
     Task<FieldGoal?> GetSingleFieldGoalAsync(int fieldGoalId);
     Task<FieldGoal?> CreateFieldGoalAsync(PlaySubmitDTO playSubmit);
     Task<FieldGoal?> CreateFieldGoalAsync(FieldGoal newFieldGoal);
-    Task<FieldGoal?> UpdateFieldGoalAsync(PlaySubmitDTO playSubmit);
-    Task<bool> DeleteFieldGoalAsync(int fieldGoalId);
+    Task<FieldGoal?> UpdateFieldGoalAsync(FieldGoal fieldGoalUpdate);
+    Task<string?> DeleteFieldGoalAsync(int fieldGoalId);
 }

--- a/the-backfield/Interfaces/PlayEntities/IFumbleRepository.cs
+++ b/the-backfield/Interfaces/PlayEntities/IFumbleRepository.cs
@@ -8,6 +8,6 @@ public interface IFumbleRepository
     Task<Fumble?> GetSingleFumbleAsync(int fumbleId);
     Task<Fumble?> CreateFumbleAsync(FumbleSubmitDTO fumbleSubmit);
     Task<Fumble?> CreateFumbleAsync(Fumble newFumble);
-    Task<Fumble?> UpdateFumbleAsync(FumbleSubmitDTO fumbleSubmit);
-    Task<bool> DeleteFumbleAsync(int fumbleId);
+    Task<Fumble?> UpdateFumbleAsync(Fumble fumbleUpdate);
+    Task<string?> DeleteFumbleAsync(int fumbleId);
 }

--- a/the-backfield/Interfaces/PlayEntities/IInterceptionRepository.cs
+++ b/the-backfield/Interfaces/PlayEntities/IInterceptionRepository.cs
@@ -8,6 +8,6 @@ public interface IInterceptionRepository
     Task<Interception?> GetSingleInterceptionAsync(int interceptionId);
     Task<Interception?> CreateInterceptionAsync(PlaySubmitDTO playSubmit);
     Task<Interception?> CreateInterceptionAsync(Interception newInterception);
-    Task<Interception?> UpdateInterceptionAsync(PlaySubmitDTO playSubmit);
-    Task<bool> DeleteInterceptionAsync(int interceptionId);
+    Task<Interception?> UpdateInterceptionAsync(Interception interceptionUpdate);
+    Task<string?> DeleteInterceptionAsync(int interceptionId);
 }

--- a/the-backfield/Interfaces/PlayEntities/IKickBlockRepository.cs
+++ b/the-backfield/Interfaces/PlayEntities/IKickBlockRepository.cs
@@ -8,6 +8,6 @@ public interface IKickBlockRepository
     Task<KickBlock?> GetSingleKickBlockAsync(int kickBlockId);
     Task<KickBlock?> CreateKickBlockAsync(PlaySubmitDTO playSubmit);
     Task<KickBlock?> CreateKickBlockAsync(KickBlock newKickBlock);
-    Task<KickBlock?> UpdateKickBlockAsync(PlaySubmitDTO playSubmit);
-    Task<bool> DeleteKickBlockAsync(int kickBlockId);
+    Task<KickBlock?> UpdateKickBlockAsync(KickBlock kickBlockUpdate);
+    Task<string?> DeleteKickBlockAsync(int kickBlockId);
 }

--- a/the-backfield/Interfaces/PlayEntities/IKickoffRepository.cs
+++ b/the-backfield/Interfaces/PlayEntities/IKickoffRepository.cs
@@ -8,6 +8,6 @@ public interface IKickoffRepository
     Task<Kickoff?> GetSingleKickoffAsync(int kickoffId);
     Task<Kickoff?> CreateKickoffAsync(PlaySubmitDTO playSubmit);
     Task<Kickoff?> CreateKickoffAsync(Kickoff newKickoff);
-    Task<Kickoff?> UpdateKickoffAsync(PlaySubmitDTO playSubmit);
-    Task<bool> DeleteKickoffAsync(int kickoffId);
+    Task<Kickoff?> UpdateKickoffAsync(Kickoff kickoffUpdate);
+    Task<string?> DeleteKickoffAsync(int kickoffId);
 }

--- a/the-backfield/Interfaces/PlayEntities/ILateralRepository.cs
+++ b/the-backfield/Interfaces/PlayEntities/ILateralRepository.cs
@@ -8,6 +8,6 @@ public interface ILateralRepository
     Task<Lateral?> GetSingleLateralAsync(int lateralId);
     Task<Lateral?> CreateLateralAsync(LateralSubmitDTO lateralSubmit);
     Task<Lateral?> CreateLateralAsync(Lateral newLateral);
-    Task<Lateral?> UpdateLateralAsync(LateralSubmitDTO lateralSubmit);
-    Task<bool> DeleteLateralAsync(int lateralId);
+    Task<Lateral?> UpdateLateralAsync(Lateral lateralUpdate);
+    Task<string?> DeleteLateralAsync(int lateralId);
 }

--- a/the-backfield/Interfaces/PlayEntities/IPassDefenseRepository.cs
+++ b/the-backfield/Interfaces/PlayEntities/IPassDefenseRepository.cs
@@ -6,5 +6,6 @@ public interface IPassDefenseRepository
 {
     Task<PassDefense?> CreatePassDefenseAsync(int playId, int defenderId);
     Task<PassDefense?> CreatePassDefenseAsync(PassDefense newPassDefense);
-    Task<bool> DeletePassDefenseAsync(int passDefenseId);
+    Task<PassDefense?> UpdatePassDefenseAsync(PassDefense passDefenseUpdate);
+    Task<string?> DeletePassDefenseAsync(int passDefenseId);
 }

--- a/the-backfield/Interfaces/PlayEntities/IPassRepository.cs
+++ b/the-backfield/Interfaces/PlayEntities/IPassRepository.cs
@@ -8,6 +8,6 @@ public interface IPassRepository
     Task<Pass?> GetSinglePassAsync(int passId);
     Task<Pass?> CreatePassAsync(PlaySubmitDTO playSubmit);
     Task<Pass?> CreatePassAsync(Pass newPass);
-    Task<Pass?> UpdatePassAsync(PlaySubmitDTO playSubmit);
-    Task<bool> DeletePassAsync(int passId);
+    Task<Pass?> UpdatePassAsync(Pass passUpdate);
+    Task<string?> DeletePassAsync(int passId);
 }

--- a/the-backfield/Interfaces/PlayEntities/IPlayPenaltyRepository.cs
+++ b/the-backfield/Interfaces/PlayEntities/IPlayPenaltyRepository.cs
@@ -8,6 +8,6 @@ public interface IPlayPenaltyRepository
     Task<PlayPenalty?> GetSinglePlayPenaltyAsync(int playPenaltyId);
     Task<PlayPenalty?> CreatePlayPenaltyAsync(PlayPenaltySubmitDTO playPenaltySubmit);
     Task<PlayPenalty?> CreatePlayPenaltyAsync(PlayPenalty newPlayPenalty);
-    Task<PlayPenalty?> UpdatePlayPenaltyAsync(PlayPenaltySubmitDTO playPenaltySubmit);
-    Task<bool> DeletePlayPenaltyAsync(int playPenaltyId);
+    Task<PlayPenalty?> UpdatePlayPenaltyAsync(PlayPenalty playPenaltyUpdate);
+    Task<string?> DeletePlayPenaltyAsync(int playPenaltyId);
 }

--- a/the-backfield/Interfaces/PlayEntities/IPuntRepository.cs
+++ b/the-backfield/Interfaces/PlayEntities/IPuntRepository.cs
@@ -8,6 +8,6 @@ public interface IPuntRepository
     Task<Punt?> GetSinglePuntAsync(int puntId);
     Task<Punt?> CreatePuntAsync(PlaySubmitDTO playSubmit);
     Task<Punt?> CreatePuntAsync(Punt newPunt);
-    Task<Punt?> UpdatePuntAsync(PlaySubmitDTO playSubmit);
-    Task<bool> DeletePuntAsync(int puntId);
+    Task<Punt?> UpdatePuntAsync(Punt puntUpdate);
+    Task<string?> DeletePuntAsync(int puntId);
 }

--- a/the-backfield/Interfaces/PlayEntities/IRushRepository.cs
+++ b/the-backfield/Interfaces/PlayEntities/IRushRepository.cs
@@ -8,6 +8,6 @@ public interface IRushRepository
     Task<Rush?> GetSingleRushAsync(int rushId);
     Task<Rush?> CreateRushAsync(PlaySubmitDTO playSubmit);
     Task<Rush?> CreateRushAsync(Rush newRush);
-    Task<Rush?> UpdateRushAsync(PlaySubmitDTO playSubmit);
-    Task<bool> DeleteRushAsync(int rushId);
+    Task<Rush?> UpdateRushAsync(Rush rushUpdate);
+    Task<string?> DeleteRushAsync(int rushId);
 }

--- a/the-backfield/Interfaces/PlayEntities/ISafetyRepository.cs
+++ b/the-backfield/Interfaces/PlayEntities/ISafetyRepository.cs
@@ -8,7 +8,7 @@ namespace TheBackfield.Interfaces.PlayEntities
         Task<Safety?> GetSingleSafetyAsync(int safetyId);
         Task<Safety?> CreateSafetyAsync(PlaySubmitDTO playSubmit);
         Task<Safety?> CreateSafetyAsync(Safety newSafety);
-        Task<Safety?> UpdateSafetyAsync(PlaySubmitDTO playSubmit);
-        Task<bool> DeleteSafetyAsync(int safetyId);
+        Task<Safety?> UpdateSafetyAsync(Safety safetyUpdate);
+        Task<string?> DeleteSafetyAsync(int safetyId);
     }
 }

--- a/the-backfield/Interfaces/PlayEntities/ITackleRepository.cs
+++ b/the-backfield/Interfaces/PlayEntities/ITackleRepository.cs
@@ -6,5 +6,6 @@ public interface ITackleRepository
 {
     Task<Tackle?> CreateTackleAsync(int playId, int tacklerId);
     Task<Tackle?> CreateTackleAsync(Tackle newTackle);
-    Task<bool> DeleteTackleAsync(int tackleId);
+    Task<Tackle?> UpdateTackleAsync(Tackle tackleUpdate);
+    Task<string?> DeleteTackleAsync(int tackleId);
 }

--- a/the-backfield/Interfaces/PlayEntities/ITouchdownRepository.cs
+++ b/the-backfield/Interfaces/PlayEntities/ITouchdownRepository.cs
@@ -8,7 +8,7 @@ namespace TheBackfield.Interfaces.PlayEntities
         Task<Touchdown?> GetSingleTouchdownAsync(int touchdownId);
         Task<Touchdown?> CreateTouchdownAsync(PlaySubmitDTO playSubmit);
         Task<Touchdown?> CreateTouchdownAsync(Touchdown newTouchdown);
-        Task<Touchdown?> UpdateTouchdownAsync(PlaySubmitDTO playSubmit);
-        Task<bool> DeleteTouchdownAsync(int touchdownId);
+        Task<Touchdown?> UpdateTouchdownAsync(Touchdown touchdownUpdate);
+        Task<string?> DeleteTouchdownAsync(int touchdownId);
     }
 }

--- a/the-backfield/Repositories/PlayEntities/ConversionRepository.cs
+++ b/the-backfield/Repositories/PlayEntities/ConversionRepository.cs
@@ -120,18 +120,76 @@ public class ConversionRepository : IConversionRepository
         return newConversion;
     }
 
-    public Task<bool> DeleteConversionAsync(int conversionId)
+    public async Task<Conversion?> UpdateConversionAsync(Conversion conversionUpdate)
     {
-        throw new NotImplementedException();
+        Conversion? conversion = await _dbContext.Conversions.FindAsync(conversionUpdate.Id);
+        if (conversion == null)
+        {
+            return null;
+        }
+
+        if (conversionUpdate.PasserId != null)
+        {
+            Player? passer = await _dbContext.Players.FindAsync(conversionUpdate.PasserId);
+            if (passer == null)
+            {
+                return null;
+            }
+        }
+        if (conversionUpdate.ReceiverId != null)
+        {
+            Player? receiver = await _dbContext.Players.FindAsync(conversionUpdate.ReceiverId);
+            if (receiver == null)
+            {
+                return null;
+            }
+        }
+        if (conversionUpdate.RusherId != null)
+        {
+            Player? rusher = await _dbContext.Players.FindAsync(conversionUpdate.RusherId);
+            if (rusher == null)
+            {
+                return null;
+            }
+        }
+        if (conversionUpdate.ReturnerId != null)
+        {
+            Player? returner = await _dbContext.Players.FindAsync(conversionUpdate.ReturnerId);
+            if (returner == null)
+            {
+                return null;
+            }
+        }
+
+        conversion.PasserId = conversionUpdate.PasserId;
+        conversion.ReceiverId = conversionUpdate.ReceiverId;
+        conversion.RusherId = conversionUpdate.RusherId;
+        conversion.TeamId = conversionUpdate.TeamId;
+        conversion.Good = conversionUpdate.Good;
+        conversion.DefensiveConversion = conversionUpdate.DefensiveConversion;
+        conversion.ReturnerId = conversionUpdate.ReturnerId;
+        conversion.ReturnTeamId = conversionUpdate.ReturnTeamId;
+
+        await _dbContext.SaveChangesAsync();
+
+        return conversion;
+    }
+
+    public async Task<string?> DeleteConversionAsync(int conversionId)
+    {
+        Conversion? conversion = await _dbContext.Conversions.FindAsync(conversionId);
+        if (conversion == null)
+        {
+            return "Invalid conversion id";
+        }
+
+        _dbContext.Conversions.Remove(conversion);
+        await _dbContext.SaveChangesAsync();
+        return null;
     }
 
     public async Task<Conversion?> GetSingleConversionAsync(int conversionId)
     {
         return await _dbContext.Conversions.AsNoTracking().SingleOrDefaultAsync(c => c.Id == conversionId);
-    }
-
-    public Task<Conversion?> UpdateConversionAsync(PlaySubmitDTO playSubmit)
-    {
-        throw new NotImplementedException();
     }
 }

--- a/the-backfield/Repositories/PlayEntities/ExtraPointRepository.cs
+++ b/the-backfield/Repositories/PlayEntities/ExtraPointRepository.cs
@@ -54,6 +54,7 @@ public class ExtraPointRepository : IExtraPointRepository
 
         return newExtraPoint;
     }
+
     public async Task<ExtraPoint?> CreateExtraPointAsync(ExtraPoint newExtraPoint)
     {
         Play? play = await _dbContext.Plays.FindAsync(newExtraPoint.PlayId);
@@ -85,18 +86,59 @@ public class ExtraPointRepository : IExtraPointRepository
         return newExtraPoint;
     }
 
-    public Task<bool> DeleteExtraPointAsync(int extraPointId)
+    public async Task<ExtraPoint?> UpdateExtraPointAsync(ExtraPoint extraPointUpdate)
     {
-        throw new NotImplementedException();
+        ExtraPoint? extraPoint = await _dbContext.ExtraPoints.FindAsync(extraPointUpdate.Id);
+        if (extraPoint == null)
+        {
+            return null;
+        }
+
+        if (extraPointUpdate.KickerId != null)
+        {
+            Player? kicker = await _dbContext.Players.FindAsync(extraPointUpdate.KickerId);
+            if (kicker == null)
+            {
+                return null;
+            }
+        }
+        if (extraPointUpdate.ReturnerId != null)
+        {
+            Player? returner = await _dbContext.Players.FindAsync(extraPointUpdate.ReturnerId);
+            if (returner == null)
+            {
+                return null;
+            }
+        }
+
+        extraPoint.KickerId = extraPointUpdate.KickerId;
+        extraPoint.TeamId = extraPointUpdate.TeamId;
+        extraPoint.Good = extraPointUpdate.Good;
+        extraPoint.Fake = extraPointUpdate.Fake;
+        extraPoint.DefensiveConversion = extraPointUpdate.DefensiveConversion;
+        extraPoint.ReturnerId = extraPointUpdate.ReturnerId;
+        extraPoint.ReturnTeamId = extraPointUpdate.ReturnTeamId;
+
+        await _dbContext.SaveChangesAsync();
+
+        return extraPoint;
+    }
+
+    public async Task<string?> DeleteExtraPointAsync(int extraPointId)
+    {
+        ExtraPoint? extraPoint = await _dbContext.ExtraPoints.FindAsync(extraPointId);
+        if (extraPoint == null)
+        {
+            return "Invalid extra point id";
+        }
+
+        _dbContext.ExtraPoints.Remove(extraPoint);
+        await _dbContext.SaveChangesAsync();
+        return null;
     }
 
     public async Task<ExtraPoint?> GetSingleExtraPointAsync(int extraPointId)
     {
         return await _dbContext.ExtraPoints.AsNoTracking().SingleOrDefaultAsync(c => c.Id == extraPointId);
-    }
-
-    public Task<ExtraPoint?> UpdateExtraPointAsync(PlaySubmitDTO playSubmit)
-    {
-        throw new NotImplementedException();
     }
 }

--- a/the-backfield/Repositories/PlayEntities/FieldGoalRepository.cs
+++ b/the-backfield/Repositories/PlayEntities/FieldGoalRepository.cs
@@ -69,18 +69,49 @@ public class FieldGoalRepository : IFieldGoalRepository
         return newFieldGoal;
     }
 
-    public Task<bool> DeleteFieldGoalAsync(int fieldGoalId)
+    public async Task<FieldGoal?> UpdateFieldGoalAsync(FieldGoal fieldGoalUpdate)
     {
-        throw new NotImplementedException();
+        FieldGoal? fieldGoal = await _dbContext.FieldGoals.FindAsync(fieldGoalUpdate.Id);
+        if (fieldGoal == null)
+        {
+            return null;
+        }
+
+        if (fieldGoalUpdate.KickerId != null)
+        {
+            Player? kicker = await _dbContext.Players.FindAsync(fieldGoalUpdate.KickerId);
+            if (kicker == null)
+            {
+                return null;
+            }
+        }
+
+        fieldGoal.KickerId = fieldGoalUpdate.KickerId;
+        fieldGoal.TeamId = fieldGoalUpdate.TeamId;
+        fieldGoal.Good = fieldGoalUpdate.Good;
+        fieldGoal.Fake = fieldGoalUpdate.Fake;
+        fieldGoal.Distance = fieldGoalUpdate.Distance;
+
+        await _dbContext.SaveChangesAsync();
+
+        return fieldGoal;
+    }
+
+    public async Task<string?> DeleteFieldGoalAsync(int fieldGoalId)
+    {
+        FieldGoal? fieldGoal = await _dbContext.FieldGoals.FindAsync(fieldGoalId);
+        if (fieldGoal == null)
+        {
+            return "Invalid field goal id";
+        }
+
+        _dbContext.FieldGoals.Remove(fieldGoal);
+        await _dbContext.SaveChangesAsync();
+        return null;
     }
 
     public async Task<FieldGoal?> GetSingleFieldGoalAsync(int fieldGoalId)
     {
         return await _dbContext.FieldGoals.AsNoTracking().SingleOrDefaultAsync(fg => fg.Id == fieldGoalId);
-    }
-
-    public Task<FieldGoal?> UpdateFieldGoalAsync(PlaySubmitDTO playSubmit)
-    {
-        throw new NotImplementedException();
     }
 }

--- a/the-backfield/Repositories/PlayEntities/FumbleRepository.cs
+++ b/the-backfield/Repositories/PlayEntities/FumbleRepository.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using Microsoft.VisualBasic;
 using TheBackfield.Data;
 using TheBackfield.DTOs.PlayEntities;
 using TheBackfield.Interfaces.PlayEntities;
@@ -67,6 +68,7 @@ public class FumbleRepository : IFumbleRepository
 
         return newFumble;
     }
+
     public async Task<Fumble?> CreateFumbleAsync(Fumble newFumble)
     {
         Play? play = await _dbContext.Plays
@@ -108,18 +110,71 @@ public class FumbleRepository : IFumbleRepository
         return newFumble;
     }
 
-    public Task<bool> DeleteFumbleAsync(int fumbleId)
+    public async Task<Fumble?> UpdateFumbleAsync(Fumble fumbleUpdate)
     {
-        throw new NotImplementedException();
+        Fumble? fumble = await _dbContext.Fumbles.SingleOrDefaultAsync(p => p.Id == fumbleUpdate.Id);
+        if (fumble == null)
+        {
+            return null;
+        }
+
+        if (fumbleUpdate.FumbleCommittedById != null)
+        {
+            Player? fumbler = await _dbContext.Players.AsNoTracking().SingleOrDefaultAsync(p => p.Id == fumbleUpdate.FumbleCommittedById);
+            if (fumbler == null)
+            {
+                return null;
+            }
+        }
+        if (fumbleUpdate.FumbleForcedById != null)
+        {
+            Player? forcedBy = await _dbContext.Players.AsNoTracking().SingleOrDefaultAsync(p => p.Id == fumbleUpdate.FumbleForcedById);
+            if (forcedBy == null)
+            {
+                return null;
+            }
+        }
+        if (fumbleUpdate.FumbleRecoveredById != null)
+        {
+            Player? recoveredBy = await _dbContext.Players.AsNoTracking().SingleOrDefaultAsync(p => p.Id == fumbleUpdate.FumbleRecoveredById);
+            if (recoveredBy == null)
+            {
+                return null;
+            }
+        }
+
+        fumble.FumbleCommittedById = fumbleUpdate.FumbleCommittedById;
+        fumble.FumbleCommittedByTeamId = fumbleUpdate.FumbleCommittedByTeamId;
+        fumble.FumbledAt = fumbleUpdate.FumbledAt;
+        fumble.FumbleForcedById = fumbleUpdate.FumbleForcedById;
+        fumble.FumbleForcedByTeamId = fumbleUpdate.FumbleForcedByTeamId;
+        fumble.FumbleRecoveredById = fumbleUpdate.FumbleRecoveredById;
+        fumble.FumbleRecoveredByTeamId = fumbleUpdate.FumbleRecoveredByTeamId;
+        fumble.RecoveredAt = fumbleUpdate.RecoveredAt;
+        fumble.LooseBallYardage = fumbleUpdate.LooseBallYardage;
+        fumble.ReturnYardage = fumbleUpdate.ReturnYardage;
+        fumble.YardageType = fumbleUpdate.YardageType;
+
+        await _dbContext.SaveChangesAsync();
+
+        return fumble;
+    }
+
+    public async Task<string?> DeleteFumbleAsync(int fumbleId)
+    {
+        Fumble? fumble = await _dbContext.Fumbles.FindAsync(fumbleId);
+        if (fumble == null)
+        {
+            return "Invalid fumble id";
+        }
+
+        _dbContext.Fumbles.Remove(fumble);
+        await _dbContext.SaveChangesAsync();
+        return null;
     }
 
     public async Task<Fumble?> GetSingleFumbleAsync(int fumbleId)
     {
         return await _dbContext.Fumbles.AsNoTracking().SingleOrDefaultAsync(f => f.Id == fumbleId);
-    }
-
-    public Task<Fumble?> UpdateFumbleAsync(FumbleSubmitDTO fumbleSubmit)
-    {
-        throw new NotImplementedException();
     }
 }

--- a/the-backfield/Repositories/PlayEntities/InterceptionRepository.cs
+++ b/the-backfield/Repositories/PlayEntities/InterceptionRepository.cs
@@ -44,6 +44,7 @@ public class InterceptionRepository : IInterceptionRepository
 
         return newInterception;
     }
+
     public async Task<Interception?> CreateInterceptionAsync(Interception newInterception)
     {
         Play? play = await _dbContext.Plays.FindAsync(newInterception.PlayId);
@@ -67,18 +68,48 @@ public class InterceptionRepository : IInterceptionRepository
         return newInterception;
     }
 
-    public Task<bool> DeleteInterceptionAsync(int interceptionId)
+    public async Task<Interception?> UpdateInterceptionAsync(Interception interceptionUpdate)
     {
-        throw new NotImplementedException();
+        Interception? interception = await _dbContext.Interceptions.FindAsync(interceptionUpdate.Id);
+        if (interception == null)
+        {
+            return null;
+        }
+
+        if (interceptionUpdate.InterceptedById != null)
+        {
+            Player? defender = await _dbContext.Players.FindAsync(interceptionUpdate.InterceptedById);
+            if (defender == null)
+            {
+                return null;
+            }
+        }
+
+        interception.InterceptedById = interceptionUpdate.InterceptedById;
+        interception.TeamId = interceptionUpdate.TeamId;
+        interception.InterceptedAt = interceptionUpdate.InterceptedAt;
+        interception.ReturnYardage = interceptionUpdate.ReturnYardage;
+
+        await _dbContext.SaveChangesAsync();
+
+        return interception;
+    }
+
+    public async Task<string?> DeleteInterceptionAsync(int interceptionId)
+    {
+        Interception? interception = await _dbContext.Interceptions.FindAsync(interceptionId);
+        if (interception == null)
+        {
+            return "Invalid interception id";
+        }
+
+        _dbContext.Interceptions.Remove(interception);
+        await _dbContext.SaveChangesAsync();
+        return null;
     }
 
     public async Task<Interception?> GetSingleInterceptionAsync(int interceptionId)
     {
         return await _dbContext.Interceptions.AsNoTracking().SingleOrDefaultAsync(i => i.Id == interceptionId);
-    }
-
-    public Task<Interception?> UpdateInterceptionAsync(PlaySubmitDTO playSubmit)
-    {
-        throw new NotImplementedException();
     }
 }

--- a/the-backfield/Repositories/PlayEntities/KickBlockRepository.cs
+++ b/the-backfield/Repositories/PlayEntities/KickBlockRepository.cs
@@ -52,6 +52,7 @@ public class KickBlockRepository : IKickBlockRepository
 
         return newKickBlock;
     }
+
     public async Task<KickBlock?> CreateKickBlockAsync(KickBlock newKickBlock)
     {
         Play? play = await _dbContext.Plays.FindAsync(newKickBlock.PlayId);
@@ -83,18 +84,59 @@ public class KickBlockRepository : IKickBlockRepository
         return newKickBlock;
     }
 
-    public Task<bool> DeleteKickBlockAsync(int kickBlockId)
+    public async Task<KickBlock?> UpdateKickBlockAsync(KickBlock kickBlockUpdate)
     {
-        throw new NotImplementedException();
+        KickBlock? kickBlock = await _dbContext.KickBlocks.FindAsync(kickBlockUpdate.Id);
+        if (kickBlock == null)
+        {
+            return null;
+        }
+
+        if (kickBlockUpdate.BlockedById != null)
+        {
+            Player? blocker = await _dbContext.Players.FindAsync(kickBlockUpdate.BlockedById);
+            if (blocker == null)
+            {
+                return null;
+            }
+        }
+        if (kickBlockUpdate.RecoveredById != null)
+        {
+            Player? recovery = await _dbContext.Players.FindAsync(kickBlockUpdate.RecoveredById);
+            if (recovery == null)
+            {
+                return null;
+            }
+        }
+
+        kickBlock.BlockedById = kickBlockUpdate.BlockedById;
+        kickBlock.BlockedByTeamId = kickBlockUpdate.BlockedByTeamId;
+        kickBlock.RecoveredById = kickBlockUpdate.RecoveredById;
+        kickBlock.RecoveredByTeamId = kickBlockUpdate.RecoveredByTeamId;
+        kickBlock.RecoveredAt = kickBlockUpdate.RecoveredAt;
+        kickBlock.LooseBallYardage = kickBlockUpdate.LooseBallYardage;
+        kickBlock.ReturnYardage = kickBlockUpdate.ReturnYardage;
+
+        await _dbContext.SaveChangesAsync();
+
+        return kickBlock;
+    }
+
+    public async Task<string?> DeleteKickBlockAsync(int kickBlockId)
+    {
+        KickBlock? kickBlock = await _dbContext.KickBlocks.FindAsync(kickBlockId);
+        if (kickBlock == null)
+        {
+            return "Invalid kick block id";
+        }
+
+        _dbContext.KickBlocks.Remove(kickBlock);
+        await _dbContext.SaveChangesAsync();
+        return null;
     }
 
     public async Task<KickBlock?> GetSingleKickBlockAsync(int kickBlockId)
     {
         return await _dbContext.KickBlocks.AsNoTracking().SingleOrDefaultAsync(kb => kb.Id == kickBlockId);
-    }
-
-    public Task<KickBlock?> UpdateKickBlockAsync(PlaySubmitDTO playSubmit)
-    {
-        throw new NotImplementedException();
     }
 }

--- a/the-backfield/Repositories/PlayEntities/KickoffRepository.cs
+++ b/the-backfield/Repositories/PlayEntities/KickoffRepository.cs
@@ -55,6 +55,7 @@ public class KickoffRepository : IKickoffRepository
 
         return newKickoff;
     }
+
     public async Task<Kickoff?> CreateKickoffAsync(Kickoff newKickoff)
     {
         Play? play = await _dbContext.Plays.FindAsync(newKickoff.PlayId);
@@ -87,18 +88,61 @@ public class KickoffRepository : IKickoffRepository
         return newKickoff;
     }
 
-    public Task<bool> DeleteKickoffAsync(int kickoffId)
+    public async Task<Kickoff?> UpdateKickoffAsync(Kickoff kickoffUpdate)
     {
-        throw new NotImplementedException();
+        Kickoff? kickoff = await _dbContext.Kickoffs.FindAsync(kickoffUpdate.Id);
+        if (kickoff == null)
+        {
+            return null;
+        }
+
+        if (kickoffUpdate.KickerId != null)
+        {
+            Player? kicker = await _dbContext.Players.FindAsync(kickoffUpdate.KickerId);
+            if (kicker == null)
+            {
+                return null;
+            }
+        }
+
+        if (kickoffUpdate.ReturnerId != null)
+        {
+            Player? returner = await _dbContext.Players.FindAsync(kickoffUpdate.ReturnerId);
+            if (returner == null)
+            {
+                return null;
+            }
+        }
+
+        kickoff.KickerId = kickoffUpdate.KickerId;
+        kickoff.TeamId = kickoffUpdate.TeamId;
+        kickoff.ReturnerId = kickoffUpdate.ReturnerId;
+        kickoff.ReturnTeamId = kickoffUpdate.ReturnTeamId;
+        kickoff.FieldedAt = kickoffUpdate.FieldedAt;
+        kickoff.Touchback = kickoffUpdate.Touchback;
+        kickoff.Distance = kickoffUpdate.Distance;
+        kickoff.ReturnYardage = kickoffUpdate.ReturnYardage;
+
+        await _dbContext.SaveChangesAsync();
+
+        return kickoff;
+    }
+
+    public async Task<string?> DeleteKickoffAsync(int kickoffId)
+    {
+        Kickoff? kickoff = await _dbContext.Kickoffs.FindAsync(kickoffId);
+        if (kickoff == null)
+        {
+            return "Invalid kickoff id";
+        }
+
+        _dbContext.Kickoffs.Remove(kickoff);
+        await _dbContext.SaveChangesAsync();
+        return null;
     }
 
     public async Task<Kickoff?> GetSingleKickoffAsync(int kickoffId)
     {
         return await _dbContext.Kickoffs.AsNoTracking().SingleOrDefaultAsync(k => k.Id == kickoffId);
-    }
-
-    public Task<Kickoff?> UpdateKickoffAsync(PlaySubmitDTO playSubmit)
-    {
-        throw new NotImplementedException();
     }
 }

--- a/the-backfield/Repositories/PlayEntities/LateralRepository.cs
+++ b/the-backfield/Repositories/PlayEntities/LateralRepository.cs
@@ -52,6 +52,7 @@ public class LateralRepository : ILateralRepository
 
         return newLateral;
     }
+
     public async Task<Lateral?> CreateLateralAsync(Lateral newLateral)
     {
         Play? play = await _dbContext.Plays
@@ -80,18 +81,61 @@ public class LateralRepository : ILateralRepository
         return newLateral;
     }
 
-    public Task<bool> DeleteLateralAsync(int lateralId)
+    public async Task<Lateral?> UpdateLateralAsync(Lateral lateralUpdate)
     {
-        throw new NotImplementedException();
+        Lateral? lateral = await _dbContext.Laterals.SingleOrDefaultAsync(p => p.Id == lateralUpdate.Id);
+
+        if (lateral == null)
+        {
+            return null;
+        }
+
+        if (lateralUpdate.PrevCarrier != null)
+        {
+            Player? prevCarrier = await _dbContext.Players.AsNoTracking().SingleOrDefaultAsync(p => p.Id == lateralUpdate.PrevCarrierId);
+            if (prevCarrier == null)
+            {
+                return null;
+            }
+        }
+
+        if (lateralUpdate.NewCarrier != null)
+        {
+            Player? newCarrier = await _dbContext.Players.AsNoTracking().SingleOrDefaultAsync(p => p.Id == lateralUpdate.NewCarrierId);
+            if (newCarrier == null)
+            {
+                return null;
+            }
+        }
+
+        lateral.PrevCarrierId = lateralUpdate.PrevCarrierId;
+        lateral.NewCarrierId = lateralUpdate.NewCarrierId;
+        lateral.TeamId = lateralUpdate.TeamId;
+        lateral.PossessionAt = lateralUpdate.PossessionAt;
+        lateral.CarriedTo = lateralUpdate.CarriedTo;
+        lateral.Yardage = lateralUpdate.Yardage;
+        lateral.YardageType = lateralUpdate.YardageType;
+
+        await _dbContext.SaveChangesAsync();
+
+        return lateral;
+    }
+
+    public async Task<string?> DeleteLateralAsync(int lateralId)
+    {
+        Lateral? lateral = await _dbContext.Laterals.FindAsync(lateralId);
+        if (lateral == null)
+        {
+            return "Invalid lateral id";
+        }
+
+        _dbContext.Laterals.Remove(lateral);
+        await _dbContext.SaveChangesAsync();
+        return null;
     }
 
     public async Task<Lateral?> GetSingleLateralAsync(int lateralId)
     {
         return await _dbContext.Laterals.AsNoTracking().SingleOrDefaultAsync(l => l.Id == lateralId);
-    }
-
-    public Task<Lateral?> UpdateLateralAsync(LateralSubmitDTO lateralSubmit)
-    {
-        throw new NotImplementedException();
     }
 }

--- a/the-backfield/Repositories/PlayEntities/PassDefenseRepository.cs
+++ b/the-backfield/Repositories/PlayEntities/PassDefenseRepository.cs
@@ -44,6 +44,7 @@ public class PassDefenseRepository : IPassDefenseRepository
 
         return newPassDefense;
     }
+
     public async Task<PassDefense?> CreatePassDefenseAsync(PassDefense newPassDefense)
     {
         Play? play = await _dbContext.Plays
@@ -69,8 +70,41 @@ public class PassDefenseRepository : IPassDefenseRepository
         return newPassDefense;
     }
 
-    public Task<bool> DeletePassDefenseAsync(int passDefenseId)
+    public async Task<PassDefense?> UpdatePassDefenseAsync(PassDefense passDefenseUpdate)
     {
-        throw new NotImplementedException();
+        PassDefense? passDefense = await _dbContext.PassDefenses.SingleOrDefaultAsync(p => p.Id == passDefenseUpdate.Id);
+        if (passDefense == null)
+        {
+            return null;
+        }
+
+        if (passDefenseUpdate.DefenderId != null)
+        {
+            Player? defender = await _dbContext.Players.AsNoTracking().SingleOrDefaultAsync(p => p.Id == passDefenseUpdate.DefenderId);
+            if (defender == null)
+            {
+                return null;
+            }
+        }
+
+        passDefense.DefenderId = passDefenseUpdate.DefenderId;
+        passDefense.TeamId = passDefenseUpdate.TeamId;
+
+        await _dbContext.SaveChangesAsync();
+
+        return passDefense;
+    }
+
+    public async Task<string?> DeletePassDefenseAsync(int passDefenseId)
+    {
+        PassDefense? passDefense = await _dbContext.PassDefenses.FindAsync(passDefenseId);
+        if (passDefense == null)
+        {
+            return "Invalid pass defense id";
+        }
+
+        _dbContext.PassDefenses.Remove(passDefense);
+        await _dbContext.SaveChangesAsync();
+        return null;
     }
 }

--- a/the-backfield/Repositories/PlayEntities/PassRepository.cs
+++ b/the-backfield/Repositories/PlayEntities/PassRepository.cs
@@ -1,6 +1,4 @@
-using System.Net.Sockets;
 using Microsoft.EntityFrameworkCore;
-using the_backfield.Migrations;
 using TheBackfield.Data;
 using TheBackfield.DTOs;
 using TheBackfield.Interfaces.PlayEntities;
@@ -58,6 +56,7 @@ public class PassRepository : IPassRepository
 
         return newPass;
     }
+
     public async Task<Pass?> CreatePassAsync(Pass newPass)
     {
         Play? play = await _dbContext.Plays
@@ -90,18 +89,62 @@ public class PassRepository : IPassRepository
         return newPass;
     }
 
-    public Task<bool> DeletePassAsync(int passId)
+    public async Task<Pass?> UpdatePassAsync(Pass passUpdate)
     {
-        throw new NotImplementedException();
+        Pass? pass = await _dbContext.Passes.SingleOrDefaultAsync(p => p.Id == passUpdate.Id);
+
+        if (pass == null)
+        {
+            return null;
+        }
+
+        if (passUpdate.PasserId != null)
+        {
+            Player? passer = await _dbContext.Players.AsNoTracking().SingleOrDefaultAsync(p => p.Id == passUpdate.PasserId);
+            if (passer == null)
+            {
+                return null;
+            }
+        }
+
+        if (passUpdate.ReceiverId != null)
+        {
+            Player? receiver = await _dbContext.Players.AsNoTracking().SingleOrDefaultAsync(p => p.Id == passUpdate.ReceiverId);
+            if (receiver == null)
+            {
+                return null;
+            }
+        }
+
+        pass.PasserId = passUpdate.PasserId;
+        pass.ReceiverId = passUpdate.ReceiverId;
+        pass.TeamId = passUpdate.TeamId;
+        pass.Completion = passUpdate.Completion;
+        pass.PassYardage = passUpdate.PassYardage;
+        pass.ReceptionYardage = passUpdate.ReceptionYardage;
+        pass.Sack = passUpdate.Sack;
+        pass.Spike = passUpdate.Spike;
+
+        await _dbContext.SaveChangesAsync();
+
+        return pass;
+    }
+
+    public async Task<string?> DeletePassAsync(int passId)
+    {
+        Pass? pass = await _dbContext.Passes.FindAsync(passId);
+        if (pass == null)
+        {
+            return "Invalid pass id";
+        }
+
+        _dbContext.Passes.Remove(pass);
+        await _dbContext.SaveChangesAsync();
+        return null;
     }
 
     public async Task<Pass?> GetSinglePassAsync(int passId)
     {
         return await _dbContext.Passes.FindAsync(passId);
-    }
-
-    public Task<Pass?> UpdatePassAsync(PlaySubmitDTO playSubmit)
-    {
-        throw new NotImplementedException();
     }
 }

--- a/the-backfield/Repositories/PlayEntities/PlayPenaltyRepository.cs
+++ b/the-backfield/Repositories/PlayEntities/PlayPenaltyRepository.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel.DataAnnotations;
 using Microsoft.EntityFrameworkCore;
 using TheBackfield.Data;
 using TheBackfield.DTOs.PlayEntities;
@@ -60,6 +61,7 @@ public class PlayPenaltyRepository : IPlayPenaltyRepository
 
         return newPlayPenalty;
     }
+
     public async Task<PlayPenalty?> CreatePlayPenaltyAsync(PlayPenalty newPlayPenalty)
     {
         Play? play = await _dbContext.Plays
@@ -91,19 +93,59 @@ public class PlayPenaltyRepository : IPlayPenaltyRepository
 
         return newPlayPenalty;
     }
-
-    public Task<bool> DeletePlayPenaltyAsync(int playPenaltyId)
+    public async Task<PlayPenalty?> UpdatePlayPenaltyAsync(PlayPenalty playPenaltyUpdate)
     {
-        throw new NotImplementedException();
+        PlayPenalty? playPenalty = await _dbContext.PlayPenalties.SingleOrDefaultAsync(p => p.Id == playPenaltyUpdate.Id);
+        if (playPenalty == null)
+        {
+            return null;
+        }
+
+        Penalty? penalty = await _dbContext.Penalties.FindAsync(playPenalty.PenaltyId);
+        if (penalty == null)
+        {
+            return null;
+        }
+
+        if (playPenaltyUpdate.PlayerId != null)
+        {
+            Player? player = await _dbContext.Players.FindAsync(playPenaltyUpdate.PlayerId);
+            if (player == null)
+            {
+                return null;
+            }
+        }
+
+        playPenalty.PenaltyId = playPenaltyUpdate.PenaltyId;
+        playPenalty.PlayerId = playPenaltyUpdate.PlayerId;
+        playPenalty.TeamId = playPenaltyUpdate.TeamId;
+        playPenalty.Enforced = playPenaltyUpdate.Enforced;
+        playPenalty.EnforcedFrom = playPenaltyUpdate.EnforcedFrom;
+        playPenalty.NoPlay = playPenaltyUpdate.NoPlay;
+        playPenalty.LossOfDown = playPenaltyUpdate.LossOfDown;
+        playPenalty.AutoFirstDown = playPenaltyUpdate.AutoFirstDown;
+        playPenalty.Yardage = playPenaltyUpdate.Yardage;
+
+        await _dbContext.SaveChangesAsync();
+
+        return playPenalty;
+    }
+
+    public async Task<string?> DeletePlayPenaltyAsync(int playPenaltyId)
+    {
+        PlayPenalty? playPenalty = await _dbContext.PlayPenalties.FindAsync(playPenaltyId);
+        if (playPenalty == null)
+        {
+            return "Invalid play penalty id";
+        }
+
+        _dbContext.PlayPenalties.Remove(playPenalty);
+        await _dbContext.SaveChangesAsync();
+        return null;
     }
 
     public async Task<PlayPenalty?> GetSinglePlayPenaltyAsync(int playPenaltyId)
     {
         return await _dbContext.PlayPenalties.AsNoTracking().SingleOrDefaultAsync(pp => pp.Id == playPenaltyId);
-    }
-
-    public Task<PlayPenalty?> UpdatePlayPenaltyAsync(PlayPenaltySubmitDTO playPenaltySubmit)
-    {
-        throw new NotImplementedException();
     }
 }

--- a/the-backfield/Repositories/PlayEntities/PuntRepository.cs
+++ b/the-backfield/Repositories/PlayEntities/PuntRepository.cs
@@ -88,18 +88,63 @@ public class PuntRepository : IPuntRepository
         return newPunt;
     }
 
-    public Task<bool> DeletePuntAsync(int puntId)
+    public async Task<Punt?> UpdatePuntAsync(Punt puntUpdate)
     {
-        throw new NotImplementedException();
+        Punt? punt = await _dbContext.Punts.FindAsync(puntUpdate.Id);
+        if (punt == null)
+        {
+            return null;
+        }
+
+        if (puntUpdate.KickerId != null)
+        {
+            Player? kicker = await _dbContext.Players.FindAsync(puntUpdate.KickerId);
+            if (kicker == null)
+            {
+                return null;
+            }
+        }
+
+        if (puntUpdate.ReturnerId != null)
+        {
+            Player? returner = await _dbContext.Players.FindAsync(puntUpdate.ReturnerId);
+            if (returner == null)
+            {
+                return null;
+            }
+        }
+
+        punt.KickerId = puntUpdate.KickerId;
+        punt.TeamId = puntUpdate.TeamId;
+        punt.ReturnerId = puntUpdate.ReturnerId;
+        punt.ReturnTeamId = puntUpdate.ReturnTeamId;
+        punt.FieldedAt = puntUpdate.FieldedAt;
+        punt.FairCatch = puntUpdate.FairCatch;
+        punt.Touchback = puntUpdate.Touchback;
+        punt.Fake = puntUpdate.Fake;
+        punt.Distance = puntUpdate.Distance;
+        punt.ReturnYardage = puntUpdate.ReturnYardage;
+
+        await _dbContext.SaveChangesAsync();
+
+        return punt;
+    }
+
+    public async Task<string?> DeletePuntAsync(int puntId)
+    {
+        Punt? punt = await _dbContext.Punts.FindAsync(puntId);
+        if (punt == null)
+        {
+            return "Invalid punt id";
+        }
+
+        _dbContext.Punts.Remove(punt);
+        await _dbContext.SaveChangesAsync();
+        return null;
     }
 
     public async Task<Punt?> GetSinglePuntAsync(int puntId)
     {
         return await _dbContext.Punts.AsNoTracking().SingleOrDefaultAsync(p => p.Id == puntId);
-    }
-
-    public Task<Punt?> UpdatePuntAsync(PlaySubmitDTO playSubmit)
-    {
-        throw new NotImplementedException();
     }
 }

--- a/the-backfield/Repositories/PlayEntities/RushRepository.cs
+++ b/the-backfield/Repositories/PlayEntities/RushRepository.cs
@@ -45,6 +45,7 @@ public class RushRepository : IRushRepository
 
         return newRush;
     }
+
     public async Task<Rush?> CreateRushAsync(Rush newRush)
     {
         Play? play = await _dbContext.Plays
@@ -67,18 +68,47 @@ public class RushRepository : IRushRepository
         return newRush;
     }
 
-    public Task<bool> DeleteRushAsync(int rushId)
+    public async Task<Rush?> UpdateRushAsync(Rush rushUpdate)
     {
-        throw new NotImplementedException();
+        Rush? rush = await _dbContext.Rushes.SingleOrDefaultAsync(p => p.Id == rushUpdate.Id);
+        if (rush == null)
+        {
+            return null;
+        }
+
+        if (rushUpdate.RusherId != null)
+        {
+            Player? rusher = await _dbContext.Players.AsNoTracking().SingleOrDefaultAsync(p => p.Id == rushUpdate.RusherId);
+            if (rusher == null)
+            {
+                return null;
+            }
+        }
+
+        rush.RusherId = rushUpdate.RusherId;
+        rush.TeamId = rushUpdate.TeamId;
+        rush.Yardage = rushUpdate.Yardage;
+
+        await _dbContext.SaveChangesAsync();
+
+        return rush;
+    }
+
+    public async Task<string?> DeleteRushAsync(int rushId)
+    {
+        Rush? rush = await _dbContext.Rushes.FindAsync(rushId);
+        if (rush == null)
+        {
+            return "Invalid rush id";
+        }
+
+        _dbContext.Rushes.Remove(rush);
+        await _dbContext.SaveChangesAsync();
+        return null;
     }
 
     public async Task<Rush?> GetSingleRushAsync(int rushId)
     {
         return await _dbContext.Rushes.FindAsync(rushId);
-    }
-
-    public Task<Rush?> UpdateRushAsync(PlaySubmitDTO playSubmit)
-    {
-        throw new NotImplementedException();
     }
 }

--- a/the-backfield/Repositories/PlayEntities/SafetyRepository.cs
+++ b/the-backfield/Repositories/PlayEntities/SafetyRepository.cs
@@ -72,19 +72,47 @@ namespace TheBackfield.Repositories.PlayEntities
             return newSafety;
         }
 
-        public Task<bool> DeleteSafetyAsync(int safetyId)
+        public async Task<Safety?> UpdateSafetyAsync(Safety safetyUpdate)
         {
-            throw new NotImplementedException();
+            Safety? safety = await _dbContext.Safeties.SingleOrDefaultAsync(p => p.Id == safetyUpdate.Id);
+            if (safety == null)
+            {
+                return null;
+            }
+
+            if (safetyUpdate.CedingPlayerId != null)
+            {
+                Player? ceding = await _dbContext.Players.AsNoTracking().SingleOrDefaultAsync(p => p.Id == safetyUpdate.CedingPlayerId);
+                if (ceding == null)
+                {
+                    return null;
+                }
+            }
+
+            safety.CedingPlayerId = safetyUpdate.CedingPlayerId;
+            safety.CedingTeamId = safetyUpdate.CedingTeamId;
+
+            await _dbContext.SaveChangesAsync();
+
+            return safety;
+        }
+
+        public async Task<string?> DeleteSafetyAsync(int safetyId)
+        {
+            Safety? safety = await _dbContext.Safeties.FindAsync(safetyId);
+            if (safety == null)
+            {
+                return "Invalid safety id";
+            }
+
+            _dbContext.Safeties.Remove(safety);
+            await _dbContext.SaveChangesAsync();
+            return null;
         }
 
         public async Task<Safety?> GetSingleSafetyAsync(int safetyId)
         {
             return await _dbContext.Safeties.AsNoTracking().SingleOrDefaultAsync(s => s.Id == safetyId);
-        }
-
-        public Task<Safety?> UpdateSafetyAsync(PlaySubmitDTO playSubmit)
-        {
-            throw new NotImplementedException();
         }
     }
 }

--- a/the-backfield/Repositories/PlayEntities/TackleRepository.cs
+++ b/the-backfield/Repositories/PlayEntities/TackleRepository.cs
@@ -65,8 +65,41 @@ public class TackleRepository : ITackleRepository
         return newTackle;
     }
 
-    public Task<bool> DeleteTackleAsync(int tackleId)
+    public async Task<Tackle?> UpdateTackleAsync(Tackle tackleUpdate)
     {
-        throw new NotImplementedException();
+        Tackle? tackle = await _dbContext.Tackles.SingleOrDefaultAsync(p => p.Id == tackleUpdate.Id);
+        if (tackle == null)
+        {
+            return null;
+        }
+
+        if (tackle.TacklerId != null)
+        {
+            Player? tackler = await _dbContext.Players.AsNoTracking().SingleOrDefaultAsync(p => p.Id == tackleUpdate.TacklerId);
+            if (tackler == null)
+            {
+                return null;
+            }
+        }
+
+        tackle.TacklerId = tackleUpdate.TacklerId;
+        tackle.TeamId = tackleUpdate.TeamId;
+
+        await _dbContext.SaveChangesAsync();
+
+        return tackle;
+    }
+
+    public async Task<string?> DeleteTackleAsync(int tackleId)
+    {
+        Tackle? tackle = await _dbContext.Tackles.FindAsync(tackleId);
+        if (tackle == null)
+        {
+            return "Invalid tackle id";
+        }
+
+        _dbContext.Tackles.Remove(tackle);
+        await _dbContext.SaveChangesAsync();
+        return null;
     }
 }

--- a/the-backfield/Repositories/PlayEntities/TouchdownRepository.cs
+++ b/the-backfield/Repositories/PlayEntities/TouchdownRepository.cs
@@ -71,9 +71,17 @@ namespace TheBackfield.Repositories.PlayEntities
             return newTouchdown;
         }
 
-        public Task<bool> DeleteTouchdownAsync(int touchdownId)
+        public async Task<string?> DeleteTouchdownAsync(int touchdownId)
         {
-            throw new NotImplementedException();
+            Touchdown? touchdown = await _dbContext.Touchdowns.FindAsync(touchdownId);
+            if (touchdown == null)
+            {
+                return "Invalid touchdown id";
+            }
+
+            _dbContext.Touchdowns.Remove(touchdown);
+            await _dbContext.SaveChangesAsync();
+            return null;
         }
 
         public async Task<Touchdown?> GetSingleTouchdownAsync(int touchdownId)
@@ -81,9 +89,29 @@ namespace TheBackfield.Repositories.PlayEntities
             return await _dbContext.Touchdowns.AsNoTracking().SingleOrDefaultAsync(t => t.Id == touchdownId);
         }
 
-        public Task<Touchdown?> UpdateTouchdownAsync(PlaySubmitDTO playSubmit)
+        public async Task<Touchdown?> UpdateTouchdownAsync(Touchdown touchdownUpdate)
         {
-            throw new NotImplementedException();
+            Touchdown? touchdown = await _dbContext.Touchdowns.SingleOrDefaultAsync(t => t.Id == touchdownUpdate.Id);
+            if (touchdown == null)
+            {
+                return null;
+            }
+
+            if (touchdownUpdate.PlayerId != null)
+            {
+                Player? player = await _dbContext.Players.AsNoTracking().SingleOrDefaultAsync(p => p.Id == touchdownUpdate.PlayerId);
+                if (player == null)
+                {
+                    return null;
+                }
+            }
+
+            touchdown.PlayerId = touchdownUpdate.PlayerId;
+            touchdown.TeamId = touchdownUpdate.TeamId;
+
+            await _dbContext.SaveChangesAsync();
+
+            return touchdown;
         }
     }
 }

--- a/the-backfield/Repositories/PlayRepository.cs
+++ b/the-backfield/Repositories/PlayRepository.cs
@@ -56,6 +56,13 @@ namespace TheBackfield.Repositories
                 return null;
             }
 
+            Team? team = await _dbContext.Teams.AsNoTracking().SingleOrDefaultAsync(t => t.Id == playUpdate.TeamId);
+            if (team == null)
+            {
+                return null;
+            }
+
+            play.TeamId = playUpdate.TeamId;
             play.FieldPositionStart = playUpdate.FieldPositionStart;
             play.FieldPositionEnd = playUpdate.FieldPositionEnd;
             play.Down = playUpdate.Down;

--- a/the-backfield/Repositories/PlayRepository.cs
+++ b/the-backfield/Repositories/PlayRepository.cs
@@ -48,6 +48,28 @@ namespace TheBackfield.Repositories
             return newPlay;
         }
 
+        public async Task<Play?> UpdatePlayAsync(PlaySubmitDTO playUpdate)
+        {
+            Play? play = await _dbContext.Plays.SingleOrDefaultAsync(p => p.Id == playUpdate.Id);
+            if (play == null)
+            {
+                return null;
+            }
+
+            play.FieldPositionStart = playUpdate.FieldPositionStart;
+            play.FieldPositionEnd = playUpdate.FieldPositionEnd;
+            play.Down = playUpdate.Down;
+            play.ToGain = playUpdate.ToGain;
+            play.ClockStart = playUpdate.ClockStart;
+            play.ClockEnd = playUpdate.ClockEnd;
+            play.GamePeriod = playUpdate.GamePeriod;
+            play.Notes = playUpdate.Notes;
+
+            await _dbContext.SaveChangesAsync();
+
+            return play;
+        }
+
         public async Task<string?> DeletePlayAsync(int playId)
         {
             Play? playToDelete = await _dbContext.Plays.FindAsync(playId);
@@ -168,11 +190,6 @@ namespace TheBackfield.Repositories
                 .Where(p => p.GameId == gameId)
                 .Where(p => Math.Abs(p.FieldPositionEnd ?? 0) == 50 && !p.Penalties.Any(pe => pe.NoPlay == true && pe.Enforced == true))
                 .ToListAsync();
-        }
-
-        public Task<Play?> UpdatePlayAsync(PlaySubmitDTO playSubmit)
-        {
-            throw new NotImplementedException();
         }
 
         public Task<List<Play>> GetCurrentDriveByGameAsync(int gameId)


### PR DESCRIPTION
Created PlayRepository.UpdatePlayAsync() that accepts PlaySubmitDTO. PrevPlayId and GameId cannot be altered with this method.

Created Update methods for all [PlayAux]Repositories, that accept new PlayAux entity. No data validation beyond ensuring that the foreign keys are valid.

Created Delete methods for all [PlayAux]Repositories, that accept PlayAuxId and return null if successful, error message as a string if not.

Updated all interfaces according to input/output parameters.