### PR TITLE
Changed Play.Game DeleteBehavior to Cascade

### DIFF
--- a/the-backfield/DTOs/PlaySubmitDTO.cs
+++ b/the-backfield/DTOs/PlaySubmitDTO.cs
@@ -53,7 +53,7 @@ namespace TheBackfield.DTOs
         public List<FumbleSubmitDTO> Fumbles { get; set; } = [];
         public int? InterceptedById { get; set; } = null;
         public int? InterceptedAt { get; set; } = null;
-        public bool KickBlocked { get; set; }
+        public bool KickBlocked { get; set; } = false;
         public int? KickBlockedById { get; set; } = null;
         public int? KickBlockRecoveredById { get; set; } = null;
         public int? KickBlockRecoveredAt { get; set; } = null;

--- a/the-backfield/Data/TheBackfieldDbContext.cs
+++ b/the-backfield/Data/TheBackfieldDbContext.cs
@@ -38,6 +38,11 @@ public class TheBackfieldDbContext : DbContext
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
+        modelBuilder.Entity<Play>()
+            .HasOne(p => p.Game)
+            .WithMany(g => g.Plays)
+            .OnDelete(DeleteBehavior.Cascade);
+
         modelBuilder.Entity<GameStat>()
             .HasOne<Team>()
             .WithMany()

--- a/the-backfield/Migrations/20250130085049_DefaultCascadeOnGameDelete.Designer.cs
+++ b/the-backfield/Migrations/20250130085049_DefaultCascadeOnGameDelete.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TheBackfield.Data;
@@ -11,9 +12,10 @@ using TheBackfield.Data;
 namespace the_backfield.Migrations
 {
     [DbContext(typeof(TheBackfieldDbContext))]
-    partial class TheBackfieldDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250130085049_DefaultCascadeOnGameDelete")]
+    partial class DefaultCascadeOnGameDelete
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/the-backfield/Migrations/20250130085049_DefaultCascadeOnGameDelete.cs
+++ b/the-backfield/Migrations/20250130085049_DefaultCascadeOnGameDelete.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace the_backfield.Migrations
+{
+    public partial class DefaultCascadeOnGameDelete : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Plays_Games_GameId",
+                table: "Plays");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Plays_Games_GameId",
+                table: "Plays",
+                column: "GameId",
+                principalTable: "Games",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Plays_Games_GameId",
+                table: "Plays");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Plays_Games_GameId",
+                table: "Plays",
+                column: "GameId",
+                principalTable: "Games",
+                principalColumn: "Id");
+        }
+    }
+}

--- a/the-backfield/Models/Play.cs
+++ b/the-backfield/Models/Play.cs
@@ -7,7 +7,7 @@ namespace TheBackfield.Models
         public int Id { get; set; }
         public int? PrevPlayId { get; set; } = null;
         public Play? PrevPlay { get; set; }
-        public int? GameId { get; set; } = null;
+        public int? GameId { get; set; }
         public Game? Game { get; set; }
         public int? TeamId { get; set; } = null;
         public Team? Team { get; set; }


### PR DESCRIPTION
GameId is nullable on Play, due to the seed play id = -1 being associated with no game. This caused the default delete behavior to be no action and prevented deletion of games due to the breaking of the FK constraint.

Explicitly defined Play-Game relationship in TheBackfieldDbContext to OnDelete behavior of Cascade.

**Pull requires an ef database update**